### PR TITLE
Polish and analytics: error handling, type safety, search, analytics

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -15,7 +15,9 @@ test.describe("Dashboard", () => {
   });
 
   test("has create new form button or limit message", async ({ page }) => {
-    // Either the "New form" link is visible or the "Limit reached" message
+    // Wait for content to load (not skeleton)
+    await page.waitForSelector("h1", { timeout: 10000 });
+
     const createButton = page.getByRole("link", { name: /new form/i });
     const limitMessage = page.getByText(/limit reached/i);
     const hasCreate = await createButton.isVisible().catch(() => false);
@@ -24,14 +26,15 @@ test.describe("Dashboard", () => {
   });
 
   test("form cards are clickable", async ({ page }) => {
-    // Verify form cards exist and are interactive
+    // Wait for actual content to load (not skeleton)
+    await page.waitForSelector("h3", { timeout: 10000 });
+
     const formHeadings = page.getByRole("heading", { level: 3 });
     const count = await formHeadings.count();
     expect(count).toBeGreaterThan(0);
 
     // Verify cards have action buttons (copy, open, duplicate, delete)
     const actionButtons = page.locator('button[title="Copy form link"]');
-    // Buttons are opacity-0 until hover, but should exist in DOM
     const buttonCount = await actionButtons.count();
     expect(buttonCount).toBeGreaterThan(0);
   });

--- a/src/actions/form-assistant.ts
+++ b/src/actions/form-assistant.ts
@@ -17,6 +17,7 @@ import {
 import { ExtendedMessage } from "@/db/schema";
 import { trackEvent } from "@/lib/jitsu-server";
 import { fireWebhook } from "@/lib/webhook";
+import { withAIErrorHandling } from "@/lib/ai-utils";
 
 // Type for the form response
 export type FormAssistantResponse = z.infer<typeof formAssistantResponseSchema>;
@@ -83,14 +84,17 @@ export async function sendMessage(
     ),
   }));
 
-  const result = await generateObject({
-    model: openai("gpt-4o-mini"),
-    schemaName: "form-assistant-response",
-    schemaDescription: "Schema for form assistant response",
-    schema: formAssistantResponseSchema,
-    messages: formattedMessages,
-    system: formAssistantSystemPrompt,
-  });
+  const result = await withAIErrorHandling((signal) =>
+    generateObject({
+      model: openai("gpt-4o-mini"),
+      schemaName: "form-assistant-response",
+      schemaDescription: "Schema for form assistant response",
+      schema: formAssistantResponseSchema,
+      messages: formattedMessages,
+      system: formAssistantSystemPrompt,
+      abortSignal: signal,
+    })
+  );
 
   const messageId = `msg-${Date.now()}-${Math.random()
     .toString(36)

--- a/src/actions/form-builder.ts
+++ b/src/actions/form-builder.ts
@@ -8,6 +8,7 @@ import { formBuilderSystemPrompt } from "@/system-prompts/builder";
 import { addFormMessages, getFormMessages, updateForm } from "@/db/storage";
 import { ExtendedMessage } from "@/db/schema";
 import { trackEvent } from "@/lib/jitsu-server";
+import { withAIErrorHandling } from "@/lib/ai-utils";
 
 // Type for the form response
 export type FormResponse = z.infer<typeof formResponseSchema>;
@@ -27,15 +28,18 @@ export async function sendMessage(formId: string, message: Message) {
   const newMessages: ExtendedMessage[] = [...messages, message];
   await addFormMessages(formId, newMessages);
 
-  const result = await generateObject({
-    model: openai("gpt-4o-mini"),
-    schemaName: "form-settings-response",
-    schemaDescription:
-      "Schema for form settings including fields configuration",
-    schema: formResponseSchema,
-    messages: newMessages,
-    system: formBuilderSystemPrompt,
-  });
+  const result = await withAIErrorHandling((signal) =>
+    generateObject({
+      model: openai("gpt-4o-mini"),
+      schemaName: "form-settings-response",
+      schemaDescription:
+        "Schema for form settings including fields configuration",
+      schema: formResponseSchema,
+      messages: newMessages,
+      system: formBuilderSystemPrompt,
+      abortSignal: signal,
+    })
+  );
 
   const messageId = `msg-${Date.now()}-${Math.random()
     .toString(36)

--- a/src/actions/form-results.ts
+++ b/src/actions/form-results.ts
@@ -4,7 +4,7 @@ import { openai } from "@ai-sdk/openai";
 import { generateObject, Message } from "ai";
 import { db } from "@/db/db";
 import { formSessions, StructuredAnswer } from "@/db/schema";
-import { and, desc, eq, isNotNull, ne } from "drizzle-orm";
+import { and, avg, count, desc, eq, isNotNull, sql } from "drizzle-orm";
 import { getFormMessages } from "@/db/storage";
 import { formOverallSummarySchema } from "@/types/promp-schema";
 import { getFormSummaryPrompt } from "@/system-prompts/results";
@@ -121,6 +121,61 @@ export async function getFormSessionsForExport(
     .orderBy(desc(formSessions.createdAt));
 
   return sessions;
+}
+
+export type FormAnalytics = {
+  totalStarted: number;
+  totalCompleted: number;
+  completionRate: number;
+  avgCompletionSeconds: number | null;
+  sentimentBreakdown: { sentiment: string; count: number }[];
+};
+
+/**
+ * Gets analytics for a form: started, completed, completion rate, avg time
+ */
+export async function getFormAnalytics(formId: string): Promise<FormAnalytics> {
+  if (!db) {
+    throw new Error("Database not initialized");
+  }
+
+  const [totals] = await db
+    .select({
+      totalStarted: count(),
+      totalCompleted: count(formSessions.completedAt),
+      avgSeconds: sql<number | null>`
+        AVG(EXTRACT(EPOCH FROM (${formSessions.completedAt} - ${formSessions.createdAt})))
+      `.as("avg_seconds"),
+    })
+    .from(formSessions)
+    .where(eq(formSessions.formId, formId));
+
+  const sentimentRows: { sentiment: string | null; count: number }[] = await db
+    .select({
+      sentiment: formSessions.overallSentiment,
+      count: count(),
+    })
+    .from(formSessions)
+    .where(
+      and(
+        eq(formSessions.formId, formId),
+        isNotNull(formSessions.overallSentiment)
+      )
+    )
+    .groupBy(formSessions.overallSentiment);
+
+  const totalStarted = totals?.totalStarted ?? 0;
+  const totalCompleted = totals?.totalCompleted ?? 0;
+
+  return {
+    totalStarted,
+    totalCompleted,
+    completionRate: totalStarted > 0 ? Math.round((totalCompleted / totalStarted) * 100) : 0,
+    avgCompletionSeconds: totals?.avgSeconds ? Math.round(totals.avgSeconds) : null,
+    sentimentBreakdown: sentimentRows
+      .filter((r) => r.sentiment !== null)
+      .map((r) => ({ sentiment: r.sentiment!, count: r.count })),
+  };
 }
 
 /**

--- a/src/actions/form-results.ts
+++ b/src/actions/form-results.ts
@@ -8,6 +8,7 @@ import { and, desc, eq, isNotNull, ne } from "drizzle-orm";
 import { getFormMessages } from "@/db/storage";
 import { formOverallSummarySchema } from "@/types/promp-schema";
 import { getFormSummaryPrompt } from "@/system-prompts/results";
+import { withAIErrorHandling } from "@/lib/ai-utils";
 
 // Define types for our response that will be used on the client
 export type FormSessionBasic = {
@@ -131,16 +132,19 @@ export async function getOverallSummary(formId: string) {
 
   const prompt = getFormSummaryPrompt(sessions, messages);
 
-  const result = await generateObject({
-    model: openai("gpt-4o-mini"),
-    messages: [
-      {
-        role: "system",
-        content: prompt,
-      },
-    ],
-    schema: formOverallSummarySchema,
-  });
+  const result = await withAIErrorHandling((signal) =>
+    generateObject({
+      model: openai("gpt-4o-mini"),
+      messages: [
+        {
+          role: "system",
+          content: prompt,
+        },
+      ],
+      schema: formOverallSummarySchema,
+      abortSignal: signal,
+    })
+  );
 
   return result.object;
 }

--- a/src/actions/simple-chat.ts
+++ b/src/actions/simple-chat.ts
@@ -3,6 +3,7 @@
 import { openai } from "@ai-sdk/openai";
 import { generateObject, Message } from "ai";
 import { z } from "zod";
+import { withAIErrorHandling } from "@/lib/ai-utils";
 
 // A simpler response schema for demonstration
 export const simpleChatSchema = z.object({
@@ -15,13 +16,16 @@ export const simpleChatSchema = z.object({
 export type SimpleChatResponse = z.infer<typeof simpleChatSchema>;
 
 export async function sendSimpleMessage(messages: Message[]) {
-  const result = await generateObject({
-    model: openai("gpt-4o-mini"),
-    schemaName: "simple-chat",
-    schemaDescription: "A simple chat response with sentiment analysis",
-    schema: simpleChatSchema,
-    messages,
-  });
+  const result = await withAIErrorHandling((signal) =>
+    generateObject({
+      model: openai("gpt-4o-mini"),
+      schemaName: "simple-chat",
+      schemaDescription: "A simple chat response with sentiment analysis",
+      schema: simpleChatSchema,
+      messages,
+      abortSignal: signal,
+    })
+  );
 
   // Add current timestamp
   const response = {

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-16">
+      <div className="flex flex-col items-center justify-center text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10 mb-4">
+          <AlertTriangle size={24} className="text-destructive" />
+        </div>
+        <h2 className="text-lg font-semibold text-foreground">
+          Something went wrong
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground max-w-sm">
+          We couldn&apos;t load your dashboard. This might be a temporary issue.
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:opacity-90 transition-opacity"
+        >
+          <RotateCcw size={14} />
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,32 @@
+export default function DashboardLoading() {
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-8">
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <div className="h-7 w-36 rounded-md bg-muted animate-pulse" />
+          <div className="mt-2 h-4 w-24 rounded-md bg-muted animate-pulse" />
+        </div>
+        <div className="h-9 w-28 rounded-lg bg-muted animate-pulse" />
+      </div>
+
+      {/* Form cards skeleton */}
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between rounded-xl border border-border bg-surface px-5 py-4"
+          >
+            <div className="flex-1 min-w-0 space-y-2">
+              <div className="h-5 w-48 rounded-md bg-muted animate-pulse" />
+              <div className="flex gap-4">
+                <div className="h-4 w-20 rounded-md bg-muted animate-pulse" />
+                <div className="h-4 w-24 rounded-md bg-muted animate-pulse" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/new/loading.tsx
+++ b/src/app/dashboard/new/loading.tsx
@@ -1,0 +1,41 @@
+export default function NewFormLoading() {
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-8">
+      <div className="mb-8">
+        <div className="h-4 w-32 rounded-md bg-muted animate-pulse mb-4" />
+        <div className="h-7 w-48 rounded-md bg-muted animate-pulse" />
+        <div className="mt-2 h-4 w-64 rounded-md bg-muted animate-pulse" />
+      </div>
+
+      {/* Blank form skeleton */}
+      <div className="mb-6 rounded-xl border-2 border-dashed border-border bg-surface p-6">
+        <div className="flex items-center gap-4">
+          <div className="h-10 w-10 rounded-lg bg-muted animate-pulse" />
+          <div className="space-y-2">
+            <div className="h-5 w-24 rounded-md bg-muted animate-pulse" />
+            <div className="h-4 w-48 rounded-md bg-muted animate-pulse" />
+          </div>
+        </div>
+      </div>
+
+      {/* Templates skeleton */}
+      <div className="mb-4">
+        <div className="h-4 w-20 rounded-md bg-muted animate-pulse" />
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-xl border border-border bg-surface p-5">
+            <div className="flex items-start gap-3">
+              <div className="h-9 w-9 shrink-0 rounded-lg bg-muted animate-pulse" />
+              <div className="flex-1 space-y-2">
+                <div className="h-5 w-32 rounded-md bg-muted animate-pulse" />
+                <div className="h-4 w-full rounded-md bg-muted animate-pulse" />
+                <div className="h-3 w-20 rounded-full bg-muted animate-pulse" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/forms/error.tsx
+++ b/src/app/forms/error.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { AlertTriangle, RotateCcw, MessageSquareText } from "lucide-react";
+
+export default function FormError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col bg-background overflow-hidden">
+      <header className="flex h-14 items-center border-b border-border bg-surface px-6 shrink-0">
+        <div className="flex items-center gap-2">
+          <MessageSquareText size={18} className="text-accent" />
+          <span className="font-semibold text-foreground">Chat Forms</span>
+        </div>
+      </header>
+
+      <div className="flex-1 flex flex-col items-center justify-center px-6 py-8">
+        <div className="w-full max-w-md text-center space-y-4">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
+            <AlertTriangle size={24} className="text-destructive" />
+          </div>
+          <h1 className="text-xl font-semibold text-foreground">
+            Unable to load this form
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Something went wrong while loading. Please try again.
+          </p>
+          <button
+            onClick={reset}
+            className="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:opacity-90 transition-opacity"
+          >
+            <RotateCcw size={14} />
+            Try again
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/forms/loading.tsx
+++ b/src/app/forms/loading.tsx
@@ -1,0 +1,19 @@
+import { MessageSquareText, Loader2 } from "lucide-react";
+
+export default function FormLoading() {
+  return (
+    <div className="flex h-full flex-col bg-background overflow-hidden">
+      <header className="flex h-14 items-center border-b border-border bg-surface px-6 shrink-0">
+        <div className="flex items-center gap-2">
+          <MessageSquareText size={18} className="text-accent" />
+          <span className="font-semibold text-foreground">Chat Forms</span>
+        </div>
+      </header>
+
+      <div className="flex-1 flex flex-col items-center justify-center px-6 py-8">
+        <Loader2 size={24} className="animate-spin text-muted-foreground" />
+        <p className="mt-3 text-sm text-muted-foreground">Loading form...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/builder/message-item.tsx
+++ b/src/components/builder/message-item.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { Bot, User } from "lucide-react";
-import { ExtendedMessage } from "./types";
+import { ExtendedMessage, FormSettings } from "./types";
 import FormSettingsSummary from "./form-settings-summary";
 
 interface MessageItemProps {
   message: ExtendedMessage;
   isLastFormUpdate: boolean;
-  formSettings: any | null;
+  formSettings: FormSettings | null;
   onDetailedView: () => void;
 }
 

--- a/src/components/builder/message-list.tsx
+++ b/src/components/builder/message-list.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useRef, useEffect } from "react";
-import { ExtendedMessage } from "./types";
+import { ExtendedMessage, FormSettings } from "./types";
 import MessageItem from "./message-item";
 
 interface MessageListProps {
   messages: ExtendedMessage[];
   lastFormUpdateMessageId: string | null;
-  formSettings: any | null;
+  formSettings: FormSettings | null;
   onDetailedView: () => void;
   isLoading?: boolean;
 }

--- a/src/components/results/form-results-panel.tsx
+++ b/src/components/results/form-results-panel.tsx
@@ -5,10 +5,12 @@ import {
   getFormSessions,
   getFormSessionDetails,
   getFormSessionsForExport,
+  getFormAnalytics,
   FormSessionBasic,
   FormSessionDetail,
+  FormAnalytics,
 } from "@/actions/form-results";
-import { AlertTriangle, Calendar, Download, RefreshCw, Loader2, Search, X } from "lucide-react";
+import { AlertTriangle, Calendar, Download, RefreshCw, Loader2, Search, X, BarChart3, Clock, TrendingUp, Users } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 
 const SENTIMENT_OPTIONS = ["all", "positive", "neutral", "negative"] as const;
@@ -25,10 +27,21 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [sentimentFilter, setSentimentFilter] = useState<SentimentFilter>("all");
+  const [analytics, setAnalytics] = useState<FormAnalytics | null>(null);
 
   useEffect(() => {
     fetchSessions();
+    fetchAnalytics();
   }, [formId]);
+
+  const fetchAnalytics = async () => {
+    try {
+      const result = await getFormAnalytics(formId);
+      setAnalytics(result);
+    } catch {
+      // Analytics are non-critical, silently fail
+    }
+  };
 
   const filteredSessions = useMemo(() => {
     let filtered = sessions;
@@ -171,6 +184,46 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
           </button>
         </div>
       </div>
+
+      {/* Analytics summary */}
+      {analytics && analytics.totalStarted > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-px border-b border-border bg-border">
+          <div className="bg-background px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-muted-foreground mb-0.5">
+              <Users size={10} />
+              <span className="text-[10px] font-medium">Started</span>
+            </div>
+            <p className="text-sm font-semibold text-foreground">{analytics.totalStarted}</p>
+          </div>
+          <div className="bg-background px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-muted-foreground mb-0.5">
+              <BarChart3 size={10} />
+              <span className="text-[10px] font-medium">Completed</span>
+            </div>
+            <p className="text-sm font-semibold text-foreground">{analytics.totalCompleted}</p>
+          </div>
+          <div className="bg-background px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-muted-foreground mb-0.5">
+              <TrendingUp size={10} />
+              <span className="text-[10px] font-medium">Completion</span>
+            </div>
+            <p className="text-sm font-semibold text-foreground">{analytics.completionRate}%</p>
+          </div>
+          <div className="bg-background px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-muted-foreground mb-0.5">
+              <Clock size={10} />
+              <span className="text-[10px] font-medium">Avg. time</span>
+            </div>
+            <p className="text-sm font-semibold text-foreground">
+              {analytics.avgCompletionSeconds
+                ? analytics.avgCompletionSeconds < 60
+                  ? `${analytics.avgCompletionSeconds}s`
+                  : `${Math.round(analytics.avgCompletionSeconds / 60)}m`
+                : "N/A"}
+            </p>
+          </div>
+        </div>
+      )}
 
       <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
         {/* List sidebar */}

--- a/src/components/results/form-results-panel.tsx
+++ b/src/components/results/form-results-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   getFormSessions,
   getFormSessionDetails,
@@ -8,8 +8,11 @@ import {
   FormSessionBasic,
   FormSessionDetail,
 } from "@/actions/form-results";
-import { AlertTriangle, Calendar, Download, RefreshCw, Loader2 } from "lucide-react";
+import { AlertTriangle, Calendar, Download, RefreshCw, Loader2, Search, X } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
+
+const SENTIMENT_OPTIONS = ["all", "positive", "neutral", "negative"] as const;
+type SentimentFilter = (typeof SENTIMENT_OPTIONS)[number];
 
 interface FormResultsPanelProps {
   formId: string;
@@ -20,10 +23,33 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
   const [sessions, setSessions] = useState<FormSessionBasic[]>([]);
   const [selectedSession, setSelectedSession] = useState<FormSessionDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sentimentFilter, setSentimentFilter] = useState<SentimentFilter>("all");
 
   useEffect(() => {
     fetchSessions();
   }, [formId]);
+
+  const filteredSessions = useMemo(() => {
+    let filtered = sessions;
+
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (s) =>
+          s.quickSummary?.toLowerCase().includes(q) ||
+          s.detailedSummary?.toLowerCase().includes(q)
+      );
+    }
+
+    if (sentimentFilter !== "all") {
+      filtered = filtered.filter(
+        (s) => s.overallSentiment?.toLowerCase() === sentimentFilter
+      );
+    }
+
+    return filtered;
+  }, [sessions, searchQuery, sentimentFilter]);
 
   const fetchSessions = async () => {
     setLoading(true);
@@ -81,6 +107,8 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
     }
   };
 
+  const hasActiveFilters = searchQuery.trim() !== "" || sentimentFilter !== "all";
+
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -119,9 +147,12 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
 
   return (
     <div className="flex h-full flex-col">
+      {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
         <span className="text-xs font-medium text-foreground">
-          {sessions.length} {sessions.length === 1 ? "response" : "responses"}
+          {hasActiveFilters
+            ? `${filteredSessions.length} of ${sessions.length} responses`
+            : `${sessions.length} ${sessions.length === 1 ? "response" : "responses"}`}
         </span>
         <div className="flex items-center gap-1">
           <button
@@ -142,27 +173,88 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
       </div>
 
       <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
-        {/* List */}
-        <div className="w-full md:w-[35%] border-b md:border-b-0 md:border-r border-border overflow-y-auto max-h-[40%] md:max-h-none">
-          {sessions.map((session) => (
-            <button
-              key={session.id}
-              onClick={() => handleSelectSession(session.id)}
-              className={`w-full text-left px-3 py-2.5 text-xs border-b border-border hover:bg-surface-hover transition-colors ${
-                selectedSession?.id === session.id ? "bg-accent/5 border-l-2 border-l-accent" : ""
-              }`}
-            >
-              <p className="font-medium text-foreground truncate">
-                {session.quickSummary || "Unlabeled"}
-              </p>
-              <p className="mt-0.5 flex items-center gap-1 text-muted-foreground">
-                <Calendar size={10} />
-                {session.createdAt
-                  ? formatDistanceToNow(new Date(session.createdAt), { addSuffix: true })
-                  : "Unknown"}
-              </p>
-            </button>
-          ))}
+        {/* List sidebar */}
+        <div className="w-full md:w-[35%] border-b md:border-b-0 md:border-r border-border flex flex-col max-h-[40%] md:max-h-none">
+          {/* Search and filters */}
+          <div className="border-b border-border p-2 space-y-1.5">
+            <div className="relative">
+              <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+              <input
+                type="text"
+                placeholder="Search responses..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full rounded-md border border-border bg-surface pl-7 pr-7 py-1.5 text-xs text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent transition-colors"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery("")}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  <X size={12} />
+                </button>
+              )}
+            </div>
+            <div className="flex gap-1">
+              {SENTIMENT_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  onClick={() => setSentimentFilter(option)}
+                  className={`rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                    sentimentFilter === option
+                      ? "bg-accent text-accent-foreground"
+                      : "bg-muted text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {option === "all" ? "All" : option.charAt(0).toUpperCase() + option.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Session list */}
+          <div className="flex-1 overflow-y-auto">
+            {filteredSessions.length === 0 ? (
+              <div className="flex items-center justify-center py-8">
+                <p className="text-xs text-muted-foreground">No matching responses</p>
+              </div>
+            ) : (
+              filteredSessions.map((session) => (
+                <button
+                  key={session.id}
+                  onClick={() => handleSelectSession(session.id)}
+                  className={`w-full text-left px-3 py-2.5 text-xs border-b border-border hover:bg-surface-hover transition-colors ${
+                    selectedSession?.id === session.id ? "bg-accent/5 border-l-2 border-l-accent" : ""
+                  }`}
+                >
+                  <p className="font-medium text-foreground truncate">
+                    {session.quickSummary || "Unlabeled"}
+                  </p>
+                  <div className="mt-0.5 flex items-center gap-2 text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <Calendar size={10} />
+                      {session.createdAt
+                        ? formatDistanceToNow(new Date(session.createdAt), { addSuffix: true })
+                        : "Unknown"}
+                    </span>
+                    {session.overallSentiment && (
+                      <span
+                        className={`rounded-full px-1.5 py-px text-[9px] font-medium ${
+                          session.overallSentiment.toLowerCase() === "positive"
+                            ? "bg-success/10 text-success"
+                            : session.overallSentiment.toLowerCase() === "negative"
+                              ? "bg-destructive/10 text-destructive"
+                              : "bg-muted text-muted-foreground"
+                        }`}
+                      >
+                        {session.overallSentiment}
+                      </span>
+                    )}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
         </div>
 
         {/* Detail */}

--- a/src/components/session-provider.tsx
+++ b/src/components/session-provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Session } from "next-auth";
 import { SessionProvider as NextAuthSessionProvider } from "next-auth/react";
 
 export function SessionProvider({
@@ -7,7 +8,7 @@ export function SessionProvider({
   session,
 }: {
   children: React.ReactNode;
-  session: any;
+  session: Session | null;
 }) {
   return (
     <NextAuthSessionProvider session={session}>

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -17,6 +17,7 @@ pool.on("error", (err) => {
   console.error("Unexpected database pool error:", err);
 });
 
+// Drizzle's type inference is too deep for TypeScript with complex schemas
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let dbInstance: any = null;
 

--- a/src/db/drizzle/0010_smart_hellion.sql
+++ b/src/db/drizzle/0010_smart_hellion.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "form_sessions" ADD COLUMN "completed_at" timestamp;

--- a/src/db/drizzle/meta/0010_snapshot.json
+++ b/src/db/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,543 @@
+{
+  "id": "6c4755aa-f7b6-487e-95bf-150fffc83ff3",
+  "prevId": "eff39f88-dd0e-40d4-99b0-accb1da5f3c5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_creation_logs": {
+      "name": "form_creation_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_creation_logs_user_id_users_id_fk": {
+          "name": "form_creation_logs_user_id_users_id_fk",
+          "tableFrom": "form_creation_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_sessions": {
+      "name": "form_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_summary": {
+          "name": "quick_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detailed_summary": {
+          "name": "detailed_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall_sentiment": {
+          "name": "overall_sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_history": {
+          "name": "message_history",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_sessions_form_id_forms_id_fk": {
+          "name": "form_sessions_form_id_forms_id_fk",
+          "tableFrom": "form_sessions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_information": {
+          "name": "key_information",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_completion_time": {
+          "name": "expected_completion_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about_business": {
+          "name": "about_business",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_to_action": {
+          "name": "call_to_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_screen_message": {
+          "name": "end_screen_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_history": {
+          "name": "message_history",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_responses": {
+          "name": "max_responses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forms_user_id_users_id_fk": {
+          "name": "forms_user_id_users_id_fk",
+          "tableFrom": "forms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1772423162556,
       "tag": "0009_square_dorian_gray",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1772424184980,
+      "tag": "0010_smart_hellion",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -54,6 +54,7 @@ export const formSessions = pgTable("form_sessions", {
   structuredData: json("structured_data").$type<StructuredAnswer[]>(),
   messageHistory: json("message_history").$type<ExtendedMessage[]>(),
   createdAt: timestamp("created_at").defaultNow(),
+  completedAt: timestamp("completed_at"),
 });
 
 export const formCreationLogs = pgTable("form_creation_logs", {

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -317,6 +317,7 @@ export const addFormSessionSummary = async (
       quickSummary: summary.quickSummary,
       overallSentiment: summary.overallSentiment,
       structuredData: summary.structuredAnswers,
+      completedAt: new Date(),
     })
     .where(eq(formSessions.id, id));
   return formSession;

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -100,6 +100,7 @@ export const getUserForms = async (userId: string) => {
       status: forms.status,
       closedAt: forms.closedAt,
       maxResponses: forms.maxResponses,
+      webhookUrl: forms.webhookUrl,
       createdAt: forms.createdAt,
       userId: forms.userId,
       responseCount: count(formSessions.id),

--- a/src/lib/ai-utils.ts
+++ b/src/lib/ai-utils.ts
@@ -1,0 +1,49 @@
+const AI_TIMEOUT_MS = 30_000; // 30 seconds
+
+export class AITimeoutError extends Error {
+  constructor() {
+    super(
+      "The AI is taking too long to respond. Please try again."
+    );
+    this.name = "AITimeoutError";
+  }
+}
+
+export class AIGenerationError extends Error {
+  constructor(originalError: unknown) {
+    const message =
+      originalError instanceof Error && originalError.message.includes("rate")
+        ? "Too many requests. Please wait a moment and try again."
+        : "Something went wrong generating a response. Please try again.";
+    super(message);
+    this.name = "AIGenerationError";
+  }
+}
+
+/**
+ * Creates an AbortSignal that times out after the configured duration.
+ * Pass this to generateObject's `abortSignal` option.
+ */
+export function aiAbortSignal(): AbortSignal {
+  return AbortSignal.timeout(AI_TIMEOUT_MS);
+}
+
+/**
+ * Wraps an AI generation call with timeout and error normalization.
+ */
+export async function withAIErrorHandling<T>(
+  fn: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const signal = aiAbortSignal();
+  try {
+    return await fn(signal);
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new AITimeoutError();
+    }
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new AITimeoutError();
+    }
+    throw new AIGenerationError(error);
+  }
+}


### PR DESCRIPTION
## Summary
- Error boundaries and loading skeletons for dashboard and form pages
- Replaced `any` types with proper TypeScript types across components
- Added 30s timeout with abort signals to all AI generation calls (4 sites)
- Response search by content and sentiment filtering in results panel
- Form analytics: completion rates, avg completion time, sentiment breakdown

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 12 E2E tests pass
- [x] Error boundaries render on server errors with retry
- [x] Loading skeletons show during page transitions
- [x] AI timeout triggers user-friendly error after 30s
- [x] Search filters responses by summary text
- [x] Sentiment pills filter by positive/neutral/negative
- [x] Analytics bar shows started/completed/rate/avg time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form analytics dashboard displaying completion metrics, rates, and sentiment breakdown
  * Response search and sentiment-based filtering in results panel

* **Improvements**
  * New loading and error states with recovery options for dashboard and form pages
  * Enhanced AI operations with automatic timeout and request cancellation handling
  * Analytics summary display on results panel when data is available

* **Bug Fixes**
  * Improved test stability with content synchronization before assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->