### PR TITLE
Robustness, validation, and engagement polish

### DIFF
--- a/src/actions/form-results.ts
+++ b/src/actions/form-results.ts
@@ -18,6 +18,8 @@ export type FormSessionBasic = {
   detailedSummary: string | null;
   overallSentiment: string | null;
   createdAt: Date | null;
+  flagged: boolean | null;
+  reviewed: boolean | null;
 };
 
 export type FormSessionDetail = FormSessionBasic & {
@@ -43,6 +45,8 @@ export async function getFormSessions(
         detailedSummary: formSessions.detailedSummary,
         overallSentiment: formSessions.overallSentiment,
         createdAt: formSessions.createdAt,
+        flagged: formSessions.flagged,
+        reviewed: formSessions.reviewed,
       })
       .from(formSessions)
       .where(
@@ -80,6 +84,8 @@ export async function getFormSessionDetails(
         overallSentiment: formSessions.overallSentiment,
         structuredData: formSessions.structuredData,
         createdAt: formSessions.createdAt,
+        flagged: formSessions.flagged,
+        reviewed: formSessions.reviewed,
       })
       .from(formSessions)
       .where(eq(formSessions.id, sessionId));
@@ -110,6 +116,8 @@ export async function getFormSessionsForExport(
       overallSentiment: formSessions.overallSentiment,
       structuredData: formSessions.structuredData,
       createdAt: formSessions.createdAt,
+      flagged: formSessions.flagged,
+      reviewed: formSessions.reviewed,
     })
     .from(formSessions)
     .where(
@@ -202,4 +210,26 @@ export async function getOverallSummary(formId: string) {
   );
 
   return result.object;
+}
+
+/**
+ * Toggle flagged status on a session
+ */
+export async function toggleSessionFlagged(sessionId: string, flagged: boolean) {
+  if (!db) throw new Error("Database not initialized");
+  await db
+    .update(formSessions)
+    .set({ flagged })
+    .where(eq(formSessions.id, sessionId));
+}
+
+/**
+ * Toggle reviewed status on a session
+ */
+export async function toggleSessionReviewed(sessionId: string, reviewed: boolean) {
+  if (!db) throw new Error("Database not initialized");
+  await db
+    .update(formSessions)
+    .set({ reviewed })
+    .where(eq(formSessions.id, sessionId));
 }

--- a/src/app/dashboard/client.tsx
+++ b/src/app/dashboard/client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FormSettings } from "@/db/schema";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import {
   Plus,
   Clock,
@@ -39,6 +39,37 @@ export default function DashboardClientPage({
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<"newest" | "oldest" | "responses" | "title">("newest");
+
+  const STORAGE_KEY = "dashboard_response_counts";
+
+  const getNewResponseCounts = useCallback(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) return {};
+      const prev: Record<string, number> = JSON.parse(stored);
+      const result: Record<string, number> = {};
+      for (const form of forms) {
+        const prevCount = prev[form.id] ?? 0;
+        const diff = form.responseCount - prevCount;
+        if (diff > 0) result[form.id] = diff;
+      }
+      return result;
+    } catch {
+      return {};
+    }
+  }, [forms]);
+
+  const [newCounts, setNewCounts] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    setNewCounts(getNewResponseCounts());
+    // Save current counts for next visit
+    const counts: Record<string, number> = {};
+    for (const form of forms) {
+      counts[form.id] = form.responseCount;
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(counts));
+  }, [forms, getNewResponseCounts]);
 
   const filteredForms = useMemo(() => {
     let result = forms;
@@ -245,13 +276,16 @@ export default function DashboardClientPage({
                   )}
                 </div>
                 <div className="mt-1 flex items-center gap-4 text-sm text-muted-foreground">
-                  {form.responseCount > 0 && (
-                    <span className="flex items-center gap-1 shrink-0">
-                      <Users size={12} />
-                      {form.responseCount}{" "}
-                      {form.responseCount === 1 ? "response" : "responses"}
-                    </span>
-                  )}
+                  <span className="flex items-center gap-1 shrink-0">
+                    <Users size={12} />
+                    {form.responseCount}{" "}
+                    {form.responseCount === 1 ? "response" : "responses"}
+                    {newCounts[form.id] && (
+                      <span className="rounded-full bg-accent px-1.5 py-px text-[10px] font-medium text-accent-foreground">
+                        +{newCounts[form.id]} new
+                      </span>
+                    )}
+                  </span>
                   {form.tone && (
                     <span className="truncate">{form.tone}</span>
                   )}

--- a/src/app/forms/[id]/page.tsx
+++ b/src/app/forms/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import FormAssistantClient from "@/components/form-assistant-client";
 import { getForm, isFormAcceptingResponses } from "@/db/storage";
 import { FormSettings } from "@/components/builder/types";
@@ -33,10 +34,12 @@ export default async function FormPage({
       className="h-full"
       {...(accentColor ? { style: { "--accent": accentColor } as React.CSSProperties } : {})}
     >
-      <FormAssistantClient
-        formId={id}
-        formSettings={formSettings as FormSettings}
-      />
+      <Suspense>
+        <FormAssistantClient
+          formId={id}
+          formSettings={formSettings as FormSettings}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/form-assistant-client.tsx
+++ b/src/components/form-assistant-client.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/actions/form-assistant";
 import { useChat } from "@/hooks/use-chat";
 import { useState, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   Send,
   MessageSquareText,
@@ -33,8 +34,11 @@ export default function FormAssistantClient({
   formSettings,
   hideHeader,
 }: FormAssistantClientProps) {
+  const searchParams = useSearchParams();
+  const prefillMessage = searchParams.get("msg");
   const [sessionId, setSessionId] = useState<string | null>(initialSessionId || null);
   const [started, setStarted] = useState(false);
+  const [prefillUsed, setPrefillUsed] = useState(false);
   const [isFormCompleted, setIsFormCompleted] = useState(false);
   const [progress, setProgress] = useState(0);
   const [allMessages, setAllMessages] = useState<ExtendedMessage[]>([]);
@@ -141,6 +145,33 @@ export default function FormAssistantClient({
     const fakeEvent = {
       preventDefault: () => {},
       target: { elements: { 0: { value: "start_form" } } },
+    } as unknown as React.FormEvent<HTMLFormElement>;
+    handleSubmit(fakeEvent);
+  };
+
+  // Auto-start with prefilled message from URL params
+  useEffect(() => {
+    if (prefillMessage && !prefillUsed && !started) {
+      setPrefillUsed(true);
+      handleStartWithMessage(prefillMessage);
+    }
+  }, [prefillMessage, prefillUsed, started]);
+
+  const handleStartWithMessage = async (msg: string) => {
+    let sid = sessionId;
+    if (!sid) {
+      const newSession = await createFormSessionAction(formId);
+      sid = newSession.id;
+      setSessionId(sid);
+    }
+
+    setStarted(true);
+    setUserMessage(msg);
+    setInputValue(msg);
+
+    const fakeEvent = {
+      preventDefault: () => {},
+      target: { elements: { 0: { value: msg } } },
     } as unknown as React.FormEvent<HTMLFormElement>;
     handleSubmit(fakeEvent);
   };

--- a/src/components/results/form-results-panel.tsx
+++ b/src/components/results/form-results-panel.tsx
@@ -6,11 +6,13 @@ import {
   getFormSessionDetails,
   getFormSessionsForExport,
   getFormAnalytics,
+  toggleSessionFlagged,
+  toggleSessionReviewed,
   FormSessionBasic,
   FormSessionDetail,
   FormAnalytics,
 } from "@/actions/form-results";
-import { AlertTriangle, Calendar, Download, RefreshCw, Loader2, Search, X, BarChart3, Clock, TrendingUp, Users } from "lucide-react";
+import { AlertTriangle, Calendar, Download, RefreshCw, Loader2, Search, X, BarChart3, Clock, TrendingUp, Users, Flag, CheckSquare } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 
 const SENTIMENT_OPTIONS = ["all", "positive", "neutral", "negative"] as const;
@@ -88,6 +90,26 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
     } catch {
       setError("Failed to load response details");
     }
+  };
+
+  const handleToggleFlag = async () => {
+    if (!selectedSession) return;
+    const newVal = !selectedSession.flagged;
+    setSelectedSession({ ...selectedSession, flagged: newVal });
+    setSessions((prev) =>
+      prev.map((s) => (s.id === selectedSession.id ? { ...s, flagged: newVal } : s))
+    );
+    await toggleSessionFlagged(selectedSession.id, newVal);
+  };
+
+  const handleToggleReviewed = async () => {
+    if (!selectedSession) return;
+    const newVal = !selectedSession.reviewed;
+    setSelectedSession({ ...selectedSession, reviewed: newVal });
+    setSessions((prev) =>
+      prev.map((s) => (s.id === selectedSession.id ? { ...s, reviewed: newVal } : s))
+    );
+    await toggleSessionReviewed(selectedSession.id, newVal);
   };
 
   const handleExport = async () => {
@@ -281,9 +303,17 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
                     selectedSession?.id === session.id ? "bg-accent/5 border-l-2 border-l-accent" : ""
                   }`}
                 >
-                  <p className="font-medium text-foreground truncate">
-                    {session.quickSummary || "Unlabeled"}
-                  </p>
+                  <div className="flex items-center gap-1.5">
+                    <p className="font-medium text-foreground truncate flex-1">
+                      {session.quickSummary || "Unlabeled"}
+                    </p>
+                    {session.flagged && (
+                      <Flag size={10} className="shrink-0 text-amber-500 fill-amber-500" />
+                    )}
+                    {session.reviewed && (
+                      <CheckSquare size={10} className="shrink-0 text-success" />
+                    )}
+                  </div>
                   <div className="mt-0.5 flex items-center gap-2 text-muted-foreground">
                     <span className="flex items-center gap-1">
                       <Calendar size={10} />
@@ -315,15 +345,41 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
         <div className="flex-1 overflow-y-auto p-4">
           {selectedSession ? (
             <div className="space-y-4">
-              <div>
-                <h3 className="font-medium text-foreground">
-                  {selectedSession.quickSummary || "Unlabeled response"}
-                </h3>
-                <p className="mt-0.5 text-xs text-muted-foreground">
-                  {selectedSession.createdAt
-                    ? formatDistanceToNow(new Date(selectedSession.createdAt), { addSuffix: true })
-                    : "Unknown date"}
-                </p>
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="font-medium text-foreground">
+                    {selectedSession.quickSummary || "Unlabeled response"}
+                  </h3>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {selectedSession.createdAt
+                      ? formatDistanceToNow(new Date(selectedSession.createdAt), { addSuffix: true })
+                      : "Unknown date"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    onClick={handleToggleFlag}
+                    aria-label={selectedSession.flagged ? "Remove flag" : "Flag response"}
+                    className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+                      selectedSession.flagged
+                        ? "bg-amber-500/10 text-amber-500"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    }`}
+                  >
+                    <Flag size={14} className={selectedSession.flagged ? "fill-amber-500" : ""} />
+                  </button>
+                  <button
+                    onClick={handleToggleReviewed}
+                    aria-label={selectedSession.reviewed ? "Mark as unreviewed" : "Mark as reviewed"}
+                    className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+                      selectedSession.reviewed
+                        ? "bg-success/10 text-success"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    }`}
+                  >
+                    <CheckSquare size={14} />
+                  </button>
+                </div>
               </div>
 
               {selectedSession.overallSentiment && (

--- a/src/components/settings/form-setting-panel.tsx
+++ b/src/components/settings/form-setting-panel.tsx
@@ -87,13 +87,46 @@ export default function FormSettingsPanel({
     handleInputChange("keyInformation", updatedKeyInformation);
   };
 
+  const validateSettings = (): string | null => {
+    if (!settings.title.trim()) {
+      return "Form title is required.";
+    }
+    if (settings.webhookUrl) {
+      try {
+        new URL(settings.webhookUrl);
+      } catch {
+        return "Webhook URL must be a valid URL (e.g., https://example.com/webhook).";
+      }
+    }
+    if (settings.maxResponses !== null && settings.maxResponses !== undefined) {
+      if (settings.maxResponses < 1) {
+        return "Max responses must be at least 1.";
+      }
+    }
+    return null;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    const validationError = validateSettings();
+    if (validationError) {
+      toast.error(validationError);
+      return;
+    }
+
+    // Clean up empty key information items before saving
+    const cleanedSettings = {
+      ...settings,
+      keyInformation: settings.keyInformation.filter((item) => item.trim() !== ""),
+    };
+
     setIsSaving(true);
 
     try {
-      onSettingsUpdate(settings);
-      setOriginalSettings(settings);
+      onSettingsUpdate(cleanedSettings);
+      setSettings(cleanedSettings);
+      setOriginalSettings(cleanedSettings);
       toast.success("Settings saved successfully");
     } catch (error) {
       toast.error("Failed to save settings");

--- a/src/db/drizzle/0013_powerful_sway.sql
+++ b/src/db/drizzle/0013_powerful_sway.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "form_sessions" ADD COLUMN "flagged" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "form_sessions" ADD COLUMN "reviewed" boolean DEFAULT false;

--- a/src/db/drizzle/meta/0013_snapshot.json
+++ b/src/db/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,570 @@
+{
+  "id": "07af3e11-77cc-40cb-8a85-908a262df693",
+  "prevId": "74c443f1-cbf1-450d-a4bc-e42f5b266e41",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_creation_logs": {
+      "name": "form_creation_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_creation_logs_user_id_users_id_fk": {
+          "name": "form_creation_logs_user_id_users_id_fk",
+          "tableFrom": "form_creation_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_sessions": {
+      "name": "form_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_summary": {
+          "name": "quick_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detailed_summary": {
+          "name": "detailed_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall_sentiment": {
+          "name": "overall_sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_history": {
+          "name": "message_history",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged": {
+          "name": "flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_sessions_form_id_forms_id_fk": {
+          "name": "form_sessions_form_id_forms_id_fk",
+          "tableFrom": "form_sessions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_information": {
+          "name": "key_information",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_completion_time": {
+          "name": "expected_completion_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about_business": {
+          "name": "about_business",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_to_action": {
+          "name": "call_to_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_screen_message": {
+          "name": "end_screen_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_history": {
+          "name": "message_history",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_responses": {
+          "name": "max_responses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'off'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forms_user_id_users_id_fk": {
+          "name": "forms_user_id_users_id_fk",
+          "tableFrom": "forms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1772425095393,
       "tag": "0012_vengeful_kingpin",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1772425597681,
+      "tag": "0013_powerful_sway",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,6 +6,7 @@ import {
   uuid,
   primaryKey,
   integer,
+  boolean,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { Message } from "@ai-sdk/react";
@@ -57,6 +58,8 @@ export const formSessions = pgTable("form_sessions", {
   messageHistory: json("message_history").$type<ExtendedMessage[]>(),
   createdAt: timestamp("created_at").defaultNow(),
   completedAt: timestamp("completed_at"),
+  flagged: boolean("flagged").default(false),
+  reviewed: boolean("reviewed").default(false),
 });
 
 export const formCreationLogs = pgTable("form_creation_logs", {


### PR DESCRIPTION
## Summary
- **Input validation**: Form settings now validate title, webhook URL format, and max responses before saving
- **URL prefill**: Forms can be pre-started with a message via `?msg=` query parameter
- **Response flagging/review**: Toggle flag and reviewed status on individual responses with optimistic UI updates and visual indicators
- **Dashboard response badges**: Response count always visible, with "new since last visit" badges tracked via localStorage

## Test plan
- [ ] Save form with empty title — validation error shown
- [ ] Save form with invalid webhook URL — validation error shown
- [ ] Open form with `?msg=Hello` — form auto-starts with that message
- [ ] Flag/unflag a response in the detail panel — icon toggles, sidebar indicator updates
- [ ] Mark a response as reviewed — checkmark appears
- [ ] Visit dashboard, submit a form response, revisit dashboard — "+N new" badge appears
- [ ] All 13 E2E tests pass