### PR TITLE
Polish: SEO, error pages, textarea inputs, conversation transcript

### DIFF
--- a/src/actions/form-results.ts
+++ b/src/actions/form-results.ts
@@ -3,7 +3,7 @@
 import { openai } from "@ai-sdk/openai";
 import { generateObject, Message } from "ai";
 import { db } from "@/db/db";
-import { formSessions, StructuredAnswer } from "@/db/schema";
+import { formSessions, StructuredAnswer, ExtendedMessage } from "@/db/schema";
 import { and, avg, count, desc, eq, isNotNull, sql } from "drizzle-orm";
 import { getFormMessages } from "@/db/storage";
 import { formOverallSummarySchema } from "@/types/promp-schema";
@@ -24,6 +24,7 @@ export type FormSessionBasic = {
 
 export type FormSessionDetail = FormSessionBasic & {
   structuredData: StructuredAnswer[] | null;
+  messageHistory: ExtendedMessage[] | null;
 };
 
 /**
@@ -83,6 +84,7 @@ export async function getFormSessionDetails(
         detailedSummary: formSessions.detailedSummary,
         overallSentiment: formSessions.overallSentiment,
         structuredData: formSessions.structuredData,
+        messageHistory: formSessions.messageHistory,
         createdAt: formSessions.createdAt,
         flagged: formSessions.flagged,
         reviewed: formSessions.reviewed,
@@ -115,6 +117,7 @@ export async function getFormSessionsForExport(
       detailedSummary: formSessions.detailedSummary,
       overallSentiment: formSessions.overallSentiment,
       structuredData: formSessions.structuredData,
+      messageHistory: formSessions.messageHistory,
       createdAt: formSessions.createdAt,
       flagged: formSessions.flagged,
       reviewed: formSessions.reviewed,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from "next";
 import DashboardClientPage from "./client";
 import { getSession } from "auth";
 import { redirect } from "next/navigation";
 import { getUserForms } from "@/db/storage";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+};
 
 export default async function DashboardPage({
   searchParams,

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6">
+      <div className="w-full max-w-md text-center space-y-4">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
+          <AlertTriangle size={24} className="text-destructive" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">
+          Something went wrong
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          An unexpected error occurred. Please try again.
+        </p>
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:opacity-90 transition-opacity"
+        >
+          <RotateCcw size={14} />
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/forms/[id]/page.tsx
+++ b/src/app/forms/[id]/page.tsx
@@ -1,9 +1,29 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import FormAssistantClient from "@/components/form-assistant-client";
 import { getForm, isFormAcceptingResponses } from "@/db/storage";
 import { FormSettings } from "@/components/builder/types";
 import { notFound } from "next/navigation";
 import FormClosedPage from "@/components/form-closed";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const form = await getForm(id);
+  if (!form) return { title: "Form Not Found" };
+  return {
+    title: form.title,
+    description: form.aboutBusiness || "Fill out this conversational form powered by AI.",
+    openGraph: {
+      title: form.title,
+      description: form.aboutBusiness || "Fill out this conversational form powered by AI.",
+      type: "website",
+    },
+  };
+}
 
 export default async function FormPage({
   params,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,8 +12,25 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Chat Forms",
-  description: "Build conversational forms powered by AI",
+  title: {
+    default: "Chat Forms – AI-Powered Conversational Forms",
+    template: "%s | Chat Forms",
+  },
+  description:
+    "Build interactive forms powered by AI. Respondents chat naturally instead of filling out fields. Higher completion rates, richer data.",
+  openGraph: {
+    type: "website",
+    siteName: "Chat Forms",
+    title: "Chat Forms – AI-Powered Conversational Forms",
+    description:
+      "Build interactive forms powered by AI. Respondents chat naturally instead of filling out fields.",
+  },
+  twitter: {
+    card: "summary",
+    title: "Chat Forms – AI-Powered Conversational Forms",
+    description:
+      "Build interactive forms powered by AI. Respondents chat naturally instead of filling out fields.",
+  },
 };
 
 export default async function RootLayout({

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,13 @@
+import type { Metadata } from "next";
 import LoginForm from "./login-form";
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "auth";
 import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+};
 
 export default async function LoginPage() {
   const session = await getServerSession(authOptions);

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { FileQuestion, ArrowLeft } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6">
+      <div className="w-full max-w-md text-center space-y-4">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+          <FileQuestion size={24} className="text-muted-foreground" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Page not found</h1>
+        <p className="text-sm text-muted-foreground">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:opacity-90 transition-opacity"
+        >
+          <ArrowLeft size={14} />
+          Back to dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,8 +1,13 @@
+import type { Metadata } from "next";
 import RegisterForm from "./register-form";
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "auth";
 import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+  title: "Create Account",
+};
 
 export default async function RegisterPage() {
   const session = await getServerSession(authOptions);

--- a/src/components/builder/input-form.tsx
+++ b/src/components/builder/input-form.tsx
@@ -22,18 +22,32 @@ export default function InputForm({ onSubmit, isLoading }: InputFormProps) {
   return (
     <div className="border-t border-border bg-surface p-3 shrink-0">
       <form onSubmit={handleSubmit} className="mx-auto max-w-2xl relative">
-        <input
-          className="w-full rounded-lg border border-border bg-background px-3 py-2.5 pr-10 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent transition-colors"
+        <textarea
+          rows={1}
+          className="w-full resize-none rounded-lg border border-border bg-background px-3 py-2.5 pr-10 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent transition-colors"
           placeholder="Describe a form you need..."
           disabled={isLoading}
           value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            e.target.style.height = "auto";
+            e.target.style.height = Math.min(e.target.scrollHeight, 120) + "px";
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              if (inputValue.trim()) {
+                const form = e.currentTarget.closest("form");
+                form?.requestSubmit();
+              }
+            }
+          }}
         />
         <button
           type="submit"
           disabled={isLoading || !inputValue.trim()}
           aria-label="Send message"
-          className="absolute right-1.5 top-1/2 -translate-y-1/2 flex h-7 w-7 items-center justify-center rounded-md bg-accent text-accent-foreground disabled:opacity-30 transition-opacity"
+          className="absolute right-1.5 bottom-2 flex h-7 w-7 items-center justify-center rounded-md bg-accent text-accent-foreground disabled:opacity-30 transition-opacity"
         >
           {isLoading ? (
             <Loader2 size={13} className="animate-spin" />

--- a/src/components/form-assistant-client.tsx
+++ b/src/components/form-assistant-client.tsx
@@ -73,7 +73,7 @@ export default function FormAssistantClient({
 
   const [inputValue, setInputValue] = useState("");
   const [userMessage, setUserMessage] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Filter out the "start_form" user message from display
@@ -290,19 +290,33 @@ export default function FormAssistantClient({
             </div>
           ) : !isFormCompleted ? (
             <form onSubmit={onSubmit} className="relative">
-              <input
+              <textarea
                 ref={inputRef}
-                className="w-full rounded-xl border border-border bg-surface px-4 py-3 pr-12 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent transition-colors"
+                rows={1}
+                className="w-full resize-none rounded-xl border border-border bg-surface px-4 py-3 pr-12 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent transition-colors"
                 placeholder="Type your response..."
                 disabled={isLoading}
                 value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
+                onChange={(e) => {
+                  setInputValue(e.target.value);
+                  e.target.style.height = "auto";
+                  e.target.style.height = Math.min(e.target.scrollHeight, 120) + "px";
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (inputValue.trim()) {
+                      const form = e.currentTarget.closest("form");
+                      form?.requestSubmit();
+                    }
+                  }
+                }}
               />
               <button
                 type="submit"
                 disabled={isLoading || !inputValue.trim()}
                 aria-label="Send message"
-                className="absolute right-2 top-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-lg bg-accent text-accent-foreground disabled:opacity-30 transition-opacity"
+                className="absolute right-2 bottom-2.5 flex h-8 w-8 items-center justify-center rounded-lg bg-accent text-accent-foreground disabled:opacity-30 transition-opacity"
               >
                 {isLoading ? (
                   <Loader2 size={14} className="animate-spin" />

--- a/src/components/results/form-results-panel.tsx
+++ b/src/components/results/form-results-panel.tsx
@@ -12,7 +12,7 @@ import {
   FormSessionDetail,
   FormAnalytics,
 } from "@/actions/form-results";
-import { AlertTriangle, Calendar, Download, RefreshCw, Loader2, Search, X, BarChart3, Clock, TrendingUp, Users, Flag, CheckSquare } from "lucide-react";
+import { AlertTriangle, Calendar, Download, RefreshCw, Loader2, Search, X, BarChart3, Clock, TrendingUp, Users, Flag, CheckSquare, MessageCircle } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 
 const SENTIMENT_OPTIONS = ["all", "positive", "neutral", "negative"] as const;
@@ -413,6 +413,34 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
                   <p className="text-sm text-foreground whitespace-pre-line">
                     {selectedSession.detailedSummary}
                   </p>
+                </div>
+              )}
+
+              {selectedSession.messageHistory && selectedSession.messageHistory.length > 0 && (
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <p className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+                    <MessageCircle size={11} />
+                    Conversation
+                  </p>
+                  <div className="space-y-2">
+                    {selectedSession.messageHistory
+                      .filter((msg) => msg.content && msg.content !== "start_form")
+                      .map((msg, i) => (
+                        <div
+                          key={i}
+                          className={`text-xs ${
+                            msg.role === "assistant"
+                              ? "text-foreground"
+                              : "text-muted-foreground pl-3 border-l-2 border-accent/30"
+                          }`}
+                        >
+                          <span className="font-medium text-[10px] uppercase tracking-wider text-muted-foreground">
+                            {msg.role === "assistant" ? "Bot" : "User"}
+                          </span>
+                          <p className="mt-0.5 whitespace-pre-line">{msg.content}</p>
+                        </div>
+                      ))}
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- **Custom 404 and error pages**: Branded not-found page and global error boundary with retry
- **SEO metadata**: OpenGraph/Twitter tags on all pages, dynamic metadata for public forms, template-based page titles
- **Auto-expanding textarea**: Chat inputs now support multi-line with Enter to submit, Shift+Enter for newline
- **Conversation transcript**: Response detail panel shows full conversation history between bot and user

## Test plan
- [ ] Visit non-existent URL — see branded 404 page with "Back to dashboard" link
- [ ] Check page titles in browser tabs (login shows "Sign In | Chat Forms", etc.)
- [ ] Share a form link — OG tags show form title and description
- [ ] Type multi-line message in form — textarea expands
- [ ] Press Enter — submits message; Shift+Enter — adds newline
- [ ] View response detail — "Conversation" section shows full message history
- [ ] All 13 E2E tests pass