### PR TITLE
Form quality: input limits, QR download, tab persistence

### DIFF
--- a/src/app/dashboard/client.tsx
+++ b/src/app/dashboard/client.tsx
@@ -279,6 +279,19 @@ export default function DashboardClientPage({
                       Limit reached
                     </span>
                   )}
+                  {form.closedAt && form.status !== "closed" && (() => {
+                    const closedAt = new Date(form.closedAt);
+                    const now = new Date();
+                    const daysLeft = Math.ceil((closedAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+                    if (daysLeft > 0 && daysLeft <= 7) {
+                      return (
+                        <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                          Closing in {daysLeft}d
+                        </span>
+                      );
+                    }
+                    return null;
+                  })()}
                 </div>
                 <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
                   <span className="flex items-center gap-1 shrink-0">

--- a/src/components/form-builder-client.tsx
+++ b/src/components/form-builder-client.tsx
@@ -32,9 +32,16 @@ export default function FormBuilder({
   formId,
   initialMessages,
 }: FormBuilderProps) {
+  const getInitialTab = (): "chat" | "settings" | "results" | "overall-summary" | "share" => {
+    if (typeof window === "undefined") return "chat";
+    const hash = window.location.hash.replace("#", "");
+    const valid = ["chat", "settings", "results", "overall-summary", "share"];
+    return valid.includes(hash) ? (hash as typeof activeTab) : "chat";
+  };
+
   const [activeTab, setActiveTab] = useState<
     "chat" | "settings" | "results" | "overall-summary" | "share"
-  >("chat");
+  >(getInitialTab);
   const [messages, setMessages] = useState<Message[]>(
     initialMessages || [
       {
@@ -71,7 +78,24 @@ export default function FormBuilder({
   const [copied, setCopied] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [showMobilePreview, setShowMobilePreview] = useState(false);
+  const [hasUnsavedSettings, setHasUnsavedSettings] = useState(false);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleTabChange = (tabId: typeof activeTab) => {
+    setActiveTab(tabId);
+    window.history.replaceState(null, "", `#${tabId}`);
+  };
+
+  // Warn before leaving with unsaved settings
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (hasUnsavedSettings) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [hasUnsavedSettings]);
 
   useEffect(() => {
     if (copied) {
@@ -131,8 +155,9 @@ export default function FormBuilder({
             {tabs.map((tab) => (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => handleTabChange(tab.id)}
                 disabled={tab.id === "settings" && !formSettings}
+                title={tab.id === "settings" && !formSettings ? "Chat with the AI to generate form settings first" : undefined}
                 className={`flex items-center gap-1.5 px-3 md:px-4 py-2.5 text-xs font-medium transition-colors border-b-2 ${
                   activeTab === tab.id
                     ? "border-accent text-accent"
@@ -167,7 +192,7 @@ export default function FormBuilder({
                 formSettingsUpdated={formSettingsUpdated}
                 setFormSettingsUpdated={setFormSettingsUpdated}
                 onMessagesUpdate={handleMessagesUpdate}
-                onDetailedView={() => setActiveTab("settings")}
+                onDetailedView={() => handleTabChange("settings")}
               />
             </div>
 
@@ -179,6 +204,7 @@ export default function FormBuilder({
                   onSettingsUpdate={(newSettings: FormSettings) =>
                     updateFormSettings(newSettings, "manual-update")
                   }
+                  onHasChanges={setHasUnsavedSettings}
                 />
               ) : (
                 <div className="h-full flex items-center justify-center text-muted-foreground text-sm">

--- a/src/components/settings/form-setting-panel.tsx
+++ b/src/components/settings/form-setting-panel.tsx
@@ -41,12 +41,14 @@ interface FormSettingsPanelProps {
   formId: string;
   formSettings: FormSettings;
   onSettingsUpdate: (settings: FormSettings) => void;
+  onHasChanges?: (hasChanges: boolean) => void;
 }
 
 export default function FormSettingsPanel({
   formId,
   formSettings,
   onSettingsUpdate,
+  onHasChanges,
 }: FormSettingsPanelProps) {
   const [settings, setSettings] = useState<FormSettings>(formSettings);
   const [originalSettings, setOriginalSettings] =
@@ -63,6 +65,7 @@ export default function FormSettingsPanel({
     const hasUnsavedChanges =
       JSON.stringify(settings) !== JSON.stringify(originalSettings);
     setHasChanges(hasUnsavedChanges);
+    onHasChanges?.(hasUnsavedChanges);
   }, [settings, originalSettings]);
 
   const handleInputChange = (
@@ -174,6 +177,7 @@ export default function FormSettingsPanel({
               <FieldGroup label="Form Title" icon={Type}>
                 <input
                   type="text"
+                  maxLength={100}
                   value={settings.title}
                   onChange={(e) => handleInputChange("title", e.target.value)}
                   className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent"
@@ -184,6 +188,7 @@ export default function FormSettingsPanel({
               <FieldGroup label="Completion Time" icon={Clock}>
                 <input
                   type="text"
+                  maxLength={30}
                   value={settings.expectedCompletionTime}
                   onChange={(e) =>
                     handleInputChange("expectedCompletionTime", e.target.value)
@@ -207,6 +212,7 @@ export default function FormSettingsPanel({
                 <FieldGroup label="Tone" icon={MessageCircle}>
                   <input
                     type="text"
+                    maxLength={50}
                     value={settings.tone}
                     onChange={(e) => handleInputChange("tone", e.target.value)}
                     className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent"
@@ -217,6 +223,7 @@ export default function FormSettingsPanel({
                 <FieldGroup label="Persona" icon={Users}>
                   <input
                     type="text"
+                    maxLength={100}
                     value={settings.persona}
                     onChange={(e) =>
                       handleInputChange("persona", e.target.value)
@@ -229,6 +236,7 @@ export default function FormSettingsPanel({
 
               <FieldGroup label="Target Audience" icon={Users}>
                 <textarea
+                  maxLength={500}
                   value={settings.targetAudience}
                   onChange={(e) =>
                     handleInputChange("targetAudience", e.target.value)
@@ -236,10 +244,12 @@ export default function FormSettingsPanel({
                   className="min-h-20 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent"
                   placeholder="Describe your target audience"
                 />
+                <CharCount value={settings.targetAudience} max={500} />
               </FieldGroup>
 
               <FieldGroup label="About Business" icon={Briefcase}>
                 <textarea
+                  maxLength={500}
                   value={settings.aboutBusiness}
                   onChange={(e) =>
                     handleInputChange("aboutBusiness", e.target.value)
@@ -247,6 +257,7 @@ export default function FormSettingsPanel({
                   className="min-h-20 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent"
                   placeholder="Tell us about your business"
                 />
+                <CharCount value={settings.aboutBusiness} max={500} />
               </FieldGroup>
             </div>
           </section>
@@ -261,6 +272,7 @@ export default function FormSettingsPanel({
             <div className="space-y-4">
               <FieldGroup label="Welcome Message" icon={Hand}>
                 <textarea
+                  maxLength={500}
                   value={settings.welcomeMessage}
                   onChange={(e) =>
                     handleInputChange("welcomeMessage", e.target.value)
@@ -268,11 +280,13 @@ export default function FormSettingsPanel({
                   className="min-h-20 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent"
                   placeholder="Message shown at the start"
                 />
+                <CharCount value={settings.welcomeMessage} max={500} />
               </FieldGroup>
 
               <FieldGroup label="Call To Action" icon={Send}>
                 <input
                   type="text"
+                  maxLength={50}
                   value={settings.callToAction}
                   onChange={(e) =>
                     handleInputChange("callToAction", e.target.value)
@@ -284,6 +298,7 @@ export default function FormSettingsPanel({
 
               <FieldGroup label="End Screen Message" icon={CheckCircle}>
                 <textarea
+                  maxLength={500}
                   value={settings.endScreenMessage}
                   onChange={(e) =>
                     handleInputChange("endScreenMessage", e.target.value)
@@ -291,6 +306,7 @@ export default function FormSettingsPanel({
                   className="min-h-20 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent"
                   placeholder="Message shown after completing the form"
                 />
+                <CharCount value={settings.endScreenMessage} max={500} />
               </FieldGroup>
             </div>
           </section>
@@ -613,5 +629,15 @@ function FieldGroup({
       </label>
       {children}
     </div>
+  );
+}
+
+function CharCount({ value, max }: { value: string; max: number }) {
+  const len = value?.length ?? 0;
+  if (len === 0) return null;
+  return (
+    <p className={`text-right text-[10px] ${len >= max ? "text-destructive" : "text-muted-foreground"}`}>
+      {len}/{max}
+    </p>
   );
 }

--- a/src/components/sharing/form-sharing-panel.tsx
+++ b/src/components/sharing/form-sharing-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Check, Copy, Link as LinkIcon, QrCode, Code2 } from "lucide-react";
+import { Check, Copy, Link as LinkIcon, QrCode, Code2, Download } from "lucide-react";
 import QRCode from "qrcode";
 
 interface FormSharingPanelProps {
@@ -11,10 +11,11 @@ interface FormSharingPanelProps {
 export default function FormSharingPanel({ formId }: FormSharingPanelProps) {
   const [copied, setCopied] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [embedHeight, setEmbedHeight] = useState(600);
 
   const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
   const formUrl = `${baseUrl}/forms/${formId}`;
-  const embedCode = `<iframe src="${formUrl}" width="100%" height="600" frameborder="0" style="border:none;border-radius:12px;"></iframe>`;
+  const embedCode = `<iframe src="${formUrl}" width="100%" height="${embedHeight}" frameborder="0" style="border:none;border-radius:12px;"></iframe>`;
 
   useEffect(() => {
     if (formUrl && baseUrl) {
@@ -25,6 +26,14 @@ export default function FormSharingPanel({ formId }: FormSharingPanelProps) {
       }).then(setQrDataUrl);
     }
   }, [formUrl, baseUrl]);
+
+  const downloadQrCode = () => {
+    if (!qrDataUrl) return;
+    const a = document.createElement("a");
+    a.href = qrDataUrl;
+    a.download = `form-qr-${formId.slice(0, 8)}.png`;
+    a.click();
+  };
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text);
@@ -73,9 +82,19 @@ export default function FormSharingPanel({ formId }: FormSharingPanelProps) {
               </div>
             )}
           </div>
-          <p className="mt-2 text-[10px] text-muted-foreground">
-            Scan with a phone camera to open the form.
-          </p>
+          <div className="mt-2 flex items-center gap-3">
+            <button
+              onClick={downloadQrCode}
+              disabled={!qrDataUrl}
+              className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-foreground hover:bg-surface-hover transition-colors disabled:opacity-50"
+            >
+              <Download size={12} />
+              Download PNG
+            </button>
+            <p className="text-[10px] text-muted-foreground">
+              Scan with a phone camera to open the form.
+            </p>
+          </div>
         </section>
 
         {/* Embed Code */}
@@ -96,7 +115,23 @@ export default function FormSharingPanel({ formId }: FormSharingPanelProps) {
               {copied === "embed" ? "Copied" : "Copy"}
             </button>
           </div>
-          <p className="mt-2 text-[10px] text-muted-foreground">
+          <div className="mt-2 flex items-center gap-2">
+            <span className="text-[10px] text-muted-foreground">Height:</span>
+            {[400, 500, 600, 700].map((h) => (
+              <button
+                key={h}
+                onClick={() => setEmbedHeight(h)}
+                className={`rounded-md px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                  embedHeight === h
+                    ? "bg-accent text-accent-foreground"
+                    : "bg-muted text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {h}px
+              </button>
+            ))}
+          </div>
+          <p className="mt-1.5 text-[10px] text-muted-foreground">
             Paste this HTML into your website to embed the form.
           </p>
         </section>


### PR DESCRIPTION
## Summary
- Added maxLength limits to all settings inputs (title: 100, tone: 50, persona: 100, CTA: 50, textareas: 500)
- Character counters on textarea fields
- QR code download as PNG button in sharing panel
- Embed code height presets (400/500/600/700px)
- Tab persistence via URL hash (survives page reloads)
- Unsaved changes warning via beforeunload event
- Tooltip on disabled Settings tab
- "Closing in Xd" badge on dashboard for forms expiring within 7 days

## Test plan
- [x] All 13 E2E tests pass
- [x] TypeScript compiles clean
- [x] Character counters appear when typing
- [x] QR download generates correct PNG
- [x] Tab hash updates in URL bar