### PR TITLE
Final polish: loading skeletons, header title, closed page, templates

### DIFF
--- a/src/app/dashboard/[id]/loading.tsx
+++ b/src/app/dashboard/[id]/loading.tsx
@@ -1,0 +1,54 @@
+export default function FormBuilderLoading() {
+  return (
+    <div className="flex flex-col h-screen bg-background">
+      {/* Header skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border bg-surface px-4">
+        <div className="flex items-center gap-3">
+          <div className="h-5 w-5 rounded bg-muted animate-pulse" />
+          <div className="h-5 w-32 rounded-md bg-muted animate-pulse" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-8 w-20 rounded-md bg-muted animate-pulse" />
+        </div>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left panel */}
+        <div className="flex flex-col w-full md:w-[45%] border-r border-border">
+          {/* Tab bar skeleton */}
+          <div className="flex border-b border-border bg-surface px-1 py-1">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="h-8 w-16 rounded-md bg-muted animate-pulse mx-1" />
+            ))}
+          </div>
+
+          {/* Chat area skeleton */}
+          <div className="flex-1 p-4 space-y-4">
+            <div className="flex gap-3">
+              <div className="h-8 w-8 rounded-full bg-muted animate-pulse shrink-0" />
+              <div className="space-y-2 flex-1">
+                <div className="h-4 w-3/4 rounded-md bg-muted animate-pulse" />
+                <div className="h-4 w-1/2 rounded-md bg-muted animate-pulse" />
+              </div>
+            </div>
+          </div>
+
+          {/* Input skeleton */}
+          <div className="border-t border-border p-4">
+            <div className="h-10 rounded-xl bg-muted animate-pulse" />
+          </div>
+        </div>
+
+        {/* Right panel - preview skeleton */}
+        <div className="hidden md:flex flex-1 flex-col">
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-center space-y-3">
+              <div className="mx-auto h-5 w-40 rounded-md bg-muted animate-pulse" />
+              <div className="mx-auto h-4 w-56 rounded-md bg-muted animate-pulse" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/new/client.tsx
+++ b/src/app/dashboard/new/client.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import { toast } from "sonner";
 
 const categoryIcons: Record<string, React.ComponentType<{ size?: number; className?: string }>> = {
+  General: FileText,
   Feedback: MessageSquareText,
   HR: Users,
   Events: CalendarCheck,
@@ -108,7 +109,7 @@ export default function TemplatePickerClient() {
       </div>
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        {formTemplates.map((template) => {
+        {formTemplates.filter((t) => t.id !== "blank").map((template) => {
           const Icon = categoryIcons[template.category] || Briefcase;
           const isCreating = creating === template.id;
 

--- a/src/components/builder/header.tsx
+++ b/src/components/builder/header.tsx
@@ -5,12 +5,14 @@ import { useRouter } from "next/navigation";
 
 interface HeaderProps {
   formId: string;
+  formTitle?: string;
   handleCopyLink: () => void;
   copied: boolean;
 }
 
 export default function Header({
   formId,
+  formTitle,
   handleCopyLink,
   copied,
 }: HeaderProps) {
@@ -26,7 +28,9 @@ export default function Header({
         >
           <ArrowLeft size={16} />
         </button>
-        <span className="text-sm font-medium text-foreground">Form Builder</span>
+        <span className="text-sm font-medium text-foreground truncate max-w-[200px] sm:max-w-none">
+          {formTitle || "Form Builder"}
+        </span>
       </div>
 
       <div className="flex items-center gap-2">

--- a/src/components/form-builder-client.tsx
+++ b/src/components/form-builder-client.tsx
@@ -143,6 +143,7 @@ export default function FormBuilder({
 
       <Header
         formId={formId}
+        formTitle={formSettings?.title}
         handleCopyLink={handleCopyLink}
         copied={copied}
       />

--- a/src/components/form-closed.tsx
+++ b/src/components/form-closed.tsx
@@ -22,10 +22,24 @@ export default function FormClosedPage({ title }: { title: string }) {
             This form is no longer accepting responses
           </h1>
           <p className="text-sm text-muted-foreground">
-            The form owner has closed this form or it has reached its response limit.
+            The form owner has closed this form or it has reached its response
+            limit. If you believe this is an error, please contact the person
+            who shared this form with you.
           </p>
         </div>
       </div>
+
+      <footer className="border-t border-border bg-surface px-6 py-3 text-center shrink-0">
+        <p className="text-[10px] text-muted-foreground">
+          Powered by{" "}
+          <a
+            href="/"
+            className="font-medium text-accent hover:underline"
+          >
+            Chat Forms
+          </a>
+        </p>
+      </footer>
     </div>
   );
 }

--- a/src/lib/form-templates.ts
+++ b/src/lib/form-templates.ts
@@ -19,6 +19,24 @@ export interface FormTemplate {
 
 export const formTemplates: FormTemplate[] = [
   {
+    id: "blank",
+    name: "Blank Form",
+    description: "Start from scratch and let AI help you build your form",
+    category: "General",
+    settings: {
+      title: "New Form",
+      tone: "",
+      persona: "",
+      targetAudience: "",
+      keyInformation: [],
+      aboutBusiness: "",
+      welcomeMessage: "Welcome! Let's get started.",
+      callToAction: "Get Started",
+      endScreenMessage: "Thank you for your response!",
+      expectedCompletionTime: "",
+    },
+  },
+  {
     id: "customer-feedback",
     name: "Customer Feedback",
     description: "Collect customer satisfaction ratings and improvement suggestions",


### PR DESCRIPTION
## Summary
- Added loading skeleton for form builder page (dashboard/[id]/loading.tsx)
- Builder header now shows the form title dynamically
- Form-closed page improved with footer branding and clearer messaging
- Added blank template to form-templates for consistent form creation flow

## Test plan
- [x] All 13 E2E tests pass
- [x] TypeScript compiles clean
- [x] Loading skeleton appears during form builder page load
- [x] Header shows form title when available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading skeleton UI for form dashboard
  * Introduced blank form template for starting from scratch
  * Form titles now display in the builder header when available
  * Added "Powered by Chat Forms" footer to closed forms

* **Improvements**
  * General template category now displays with an icon
  * Enhanced messaging for closed forms with explanatory text and contact options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->