### PR TITLE
Auth rate limiting, powered-by footer, and builder metadata

### DIFF
--- a/e2e/form-submission.spec.ts
+++ b/e2e/form-submission.spec.ts
@@ -50,7 +50,7 @@ test.describe("Form Submission (Public)", () => {
     }
 
     // Should see the form header
-    await expect(page.locator("text=Chat Forms")).toBeVisible();
+    await expect(page.locator("header >> text=Chat Forms")).toBeVisible();
 
     // Should see the form title or closed message (form may be closed)
     const formTitle = page.locator("p:text('Customer Satisfaction Survey')");

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -7,7 +7,13 @@ import bcrypt from "bcryptjs";
 import { z } from "zod";
 import { redirect } from "next/navigation";
 import { v4 as uuidv4 } from "uuid";
-import { cookies } from "next/headers";
+import { headers } from "next/headers";
+import { rateLimit } from "@/lib/rate-limit";
+
+async function getClientIp(): Promise<string> {
+  const h = await headers();
+  return h.get("x-forwarded-for")?.split(",")[0]?.trim() || h.get("x-real-ip") || "unknown";
+}
 
 // Login schema
 const loginSchema = z.object({
@@ -59,6 +65,13 @@ export async function login(
 ): Promise<LoginFormState> {
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
+
+  // Rate limit: 5 login attempts per minute per IP
+  const ip = await getClientIp();
+  const rl = rateLimit(`login:${ip}`, { maxRequests: 5, windowMs: 60_000 });
+  if (!rl.allowed) {
+    return { error: "Too many login attempts. Please wait a moment and try again." };
+  }
 
   // Validate input
   const validatedFields = loginSchema.safeParse({
@@ -113,6 +126,13 @@ export async function register(
   const name = formData.get("name") as string;
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
+
+  // Rate limit: 3 registrations per minute per IP
+  const ip = await getClientIp();
+  const rl = rateLimit(`register:${ip}`, { maxRequests: 3, windowMs: 60_000 });
+  if (!rl.allowed) {
+    return { error: "Too many registration attempts. Please wait a moment and try again." };
+  }
 
   // Validate input
   const validatedFields = registerSchema.safeParse({

--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -34,5 +34,5 @@ export default async function FormBuilderPage({
     });
   }
 
-  return <FormBuilderClient formId={id} initialMessages={messages} />;
+  return <FormBuilderClient formId={id} initialMessages={messages} createdAt={form?.createdAt?.toISOString()} />;
 }

--- a/src/app/dashboard/new/page.tsx
+++ b/src/app/dashboard/new/page.tsx
@@ -2,8 +2,13 @@ import { getSession } from "auth";
 import { redirect } from "next/navigation";
 import { getUserForms } from "@/db/storage";
 import TemplatePickerClient from "./client";
+import type { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Create Form",
+};
 
 const MAX_FORMS = 10;
 

--- a/src/components/builder/header.tsx
+++ b/src/components/builder/header.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 interface HeaderProps {
   formId: string;
   formTitle?: string;
+  createdAt?: string;
   handleCopyLink: () => void;
   copied: boolean;
 }
@@ -13,6 +14,7 @@ interface HeaderProps {
 export default function Header({
   formId,
   formTitle,
+  createdAt,
   handleCopyLink,
   copied,
 }: HeaderProps) {
@@ -31,6 +33,11 @@ export default function Header({
         <span className="text-sm font-medium text-foreground truncate max-w-[200px] sm:max-w-none">
           {formTitle || "Form Builder"}
         </span>
+        {createdAt && (
+          <span className="hidden sm:inline text-xs text-muted-foreground">
+            Created {new Date(createdAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+          </span>
+        )}
       </div>
 
       <div className="flex items-center gap-2">

--- a/src/components/form-assistant-client.tsx
+++ b/src/components/form-assistant-client.tsx
@@ -347,6 +347,21 @@ export default function FormAssistantClient({
           )}
         </div>
       </div>
+
+      {/* Powered-by footer — only on standalone public form pages */}
+      {!hideHeader && (
+        <footer className="border-t border-border bg-surface px-6 py-3 text-center shrink-0">
+          <p className="text-[10px] text-muted-foreground">
+            Powered by{" "}
+            <a
+              href="/"
+              className="font-medium text-accent hover:underline"
+            >
+              Chat Forms
+            </a>
+          </p>
+        </footer>
+      )}
     </div>
   );
 }

--- a/src/components/form-builder-client.tsx
+++ b/src/components/form-builder-client.tsx
@@ -18,6 +18,7 @@ import FormSharingPanel from "./sharing/form-sharing-panel";
 interface FormBuilderProps {
   formId: string;
   initialMessages?: Message[];
+  createdAt?: string;
 }
 
 const tabs = [
@@ -31,6 +32,7 @@ const tabs = [
 export default function FormBuilder({
   formId,
   initialMessages,
+  createdAt,
 }: FormBuilderProps) {
   const getInitialTab = (): "chat" | "settings" | "results" | "overall-summary" | "share" => {
     if (typeof window === "undefined") return "chat";
@@ -144,6 +146,7 @@ export default function FormBuilder({
       <Header
         formId={formId}
         formTitle={formSettings?.title}
+        createdAt={createdAt}
         handleCopyLink={handleCopyLink}
         copied={copied}
       />


### PR DESCRIPTION
## Summary
- Rate limit login (5/min) and registration (3/min) endpoints per IP to prevent brute-force attacks
- Add `<title>Create Form</title>` metadata to the new form page
- Add powered-by footer to public form assistant view (hidden in builder preview)
- Show form creation date in builder header
- Fix E2E test selector to scope header text match, avoiding footer ambiguity

## Test plan
- [x] TypeScript compiles clean
- [x] All 13 E2E tests pass
- [ ] Verify login rate limit returns error after 5 rapid attempts
- [ ] Verify registration rate limit returns error after 3 rapid attempts
- [ ] Verify powered-by footer appears on public form pages but not in builder preview
- [ ] Verify creation date appears in builder header on desktop