### PR TITLE
Extract constants, add page metadata, and input limits

### DIFF
--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -1,9 +1,21 @@
+import type { Metadata } from "next";
 import FormBuilderClient from "@/components/form-builder-client";
 import { getForm, getFormMessages } from "@/db/storage";
 import { getSession } from "auth";
 import { redirect } from "next/navigation";
+import { INITIAL_BUILDER_MESSAGE } from "@/lib/constants";
 
 export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const form = await getForm(id);
+  return { title: form?.title || "Form Builder" };
+}
 
 export default async function FormBuilderPage({
   params,
@@ -29,8 +41,7 @@ export default async function FormBuilderPage({
     messages.push({
       id: "initial-message",
       role: "assistant",
-      content:
-        "Let's start creating the form. Give me an idea of what is form created for?",
+      content: INITIAL_BUILDER_MESSAGE,
     });
   }
 

--- a/src/app/dashboard/client.tsx
+++ b/src/app/dashboard/client.tsx
@@ -21,8 +21,7 @@ import { useRouter } from "next/navigation";
 import { formatDistanceToNow } from "date-fns";
 import { deleteFormAction, duplicateFormAction } from "@/actions/form-management";
 import { toast } from "sonner";
-
-const MAX_FORMS = 10;
+import { MAX_FORMS_PER_USER } from "@/lib/constants";
 
 type FormWithCount = FormSettings & { responseCount: number };
 
@@ -33,7 +32,7 @@ export default function DashboardClientPage({
   forms: FormWithCount[];
   error?: string;
 }) {
-  const atLimit = forms.length >= MAX_FORMS;
+  const atLimit = forms.length >= MAX_FORMS_PER_USER;
   const router = useRouter();
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -173,7 +172,7 @@ export default function DashboardClientPage({
         {atLimit ? (
           <span className="inline-flex items-center gap-2 rounded-lg bg-muted px-4 py-2 text-sm font-medium text-muted-foreground cursor-not-allowed">
             <Plus size={16} />
-            Limit reached ({MAX_FORMS})
+            Limit reached ({MAX_FORMS_PER_USER})
           </span>
         ) : (
           <Link
@@ -190,7 +189,7 @@ export default function DashboardClientPage({
       {error === "limit" && (
         <div className="mb-6 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
           <MessageSquareText size={16} className="shrink-0" />
-          <span>You&apos;ve reached the limit of {MAX_FORMS} forms. Delete an existing form to create a new one.</span>
+          <span>You&apos;ve reached the limit of {MAX_FORMS_PER_USER} forms. Delete an existing form to create a new one.</span>
         </div>
       )}
 

--- a/src/app/dashboard/new/page.tsx
+++ b/src/app/dashboard/new/page.tsx
@@ -2,6 +2,7 @@ import { getSession } from "auth";
 import { redirect } from "next/navigation";
 import { getUserForms } from "@/db/storage";
 import TemplatePickerClient from "./client";
+import { MAX_FORMS_PER_USER } from "@/lib/constants";
 import type { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
@@ -10,8 +11,6 @@ export const metadata: Metadata = {
   title: "Create Form",
 };
 
-const MAX_FORMS = 10;
-
 export default async function NewFormPage() {
   const session = await getSession();
   if (!session?.user?.id) {
@@ -19,7 +18,7 @@ export default async function NewFormPage() {
   }
 
   const forms = await getUserForms(session.user.id);
-  if (forms.length >= MAX_FORMS) {
+  if (forms.length >= MAX_FORMS_PER_USER) {
     redirect("/dashboard?error=limit");
   }
 

--- a/src/components/builder/form-builder-chat.tsx
+++ b/src/components/builder/form-builder-chat.tsx
@@ -7,6 +7,7 @@ import { Message } from "@ai-sdk/react";
 import { ExtendedMessage, FormSettings } from "./types";
 import MessageList from "./message-list";
 import InputForm from "./input-form";
+import { INITIAL_BUILDER_MESSAGE } from "@/lib/constants";
 
 interface FormBuilderClientProps {
   formId: string;
@@ -42,7 +43,7 @@ export default function FormBuilderChat({
       {
         id: "initial-message",
         role: "assistant",
-        content: "Let's start creating the form. Give me an idea of what is form created for?",
+        content: INITIAL_BUILDER_MESSAGE,
       },
     ],
   });

--- a/src/components/builder/input-form.tsx
+++ b/src/components/builder/input-form.tsx
@@ -26,6 +26,7 @@ export default function InputForm({ onSubmit, isLoading }: InputFormProps) {
           rows={1}
           className="w-full resize-none rounded-lg border border-border bg-background px-3 py-2.5 pr-10 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent transition-colors"
           placeholder="Describe a form you need..."
+          maxLength={2000}
           disabled={isLoading}
           value={inputValue}
           onChange={(e) => {

--- a/src/components/form-assistant-client.tsx
+++ b/src/components/form-assistant-client.tsx
@@ -295,6 +295,7 @@ export default function FormAssistantClient({
                 rows={1}
                 className="w-full resize-none rounded-xl border border-border bg-surface px-4 py-3 pr-12 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:ring-1 focus:ring-accent transition-colors"
                 placeholder="Type your response..."
+                maxLength={1000}
                 disabled={isLoading}
                 value={inputValue}
                 onChange={(e) => {

--- a/src/components/form-builder-client.tsx
+++ b/src/components/form-builder-client.tsx
@@ -14,6 +14,7 @@ import { createFormSessionAction } from "@/actions/form-assistant";
 import FormResultsPanel from "./results/form-results-panel";
 import FormSummaryPanel from "./results/form-summary-panel";
 import FormSharingPanel from "./sharing/form-sharing-panel";
+import { INITIAL_BUILDER_MESSAGE } from "@/lib/constants";
 
 interface FormBuilderProps {
   formId: string;
@@ -50,7 +51,7 @@ export default function FormBuilder({
         id: "initial-message",
         role: "assistant",
         content:
-          "Let's start creating the form. Give me an idea of what is form created for?",
+          INITIAL_BUILDER_MESSAGE,
       },
     ]
   );

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -12,8 +12,7 @@ import {
 import { db } from "@/db/db";
 import { and, count, desc, eq, gte, lte } from "drizzle-orm";
 import { FormAssistantResponse } from "@/actions/form-assistant";
-
-const MAX_FORMS_PER_USER = 10;
+import { MAX_FORMS_PER_USER } from "@/lib/constants";
 
 export const createForm = async (newForm: FormSettingsInsert) => {
   if (!db) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,4 @@
+export const MAX_FORMS_PER_USER = 10;
+
+export const INITIAL_BUILDER_MESSAGE =
+  "Let's start creating the form. Give me an idea of what is form created for?";


### PR DESCRIPTION
## Summary
- Extract `MAX_FORMS_PER_USER` and `INITIAL_BUILDER_MESSAGE` into `src/lib/constants.ts`, removing duplication across 6 files
- Add dynamic `generateMetadata` to form builder page for proper browser tab titles
- Add `maxLength` to builder chat input (2000 chars) and form assistant input (1000 chars)

## Test plan
- [x] TypeScript compiles clean
- [x] All 13 E2E tests pass
- [ ] Verify form builder page shows form title in browser tab
- [ ] Verify chat inputs enforce character limits