### PR TITLE
Fix export bug, empty summary state, and a11y improvements

### DIFF
--- a/src/actions/form-results.ts
+++ b/src/actions/form-results.ts
@@ -232,6 +232,12 @@ export async function getFormAnalytics(formId: string): Promise<FormAnalytics> {
 export async function getOverallSummary(formId: string) {
   // requireFormOwnership is called inside getFormSessions
   const sessions = await getFormSessions(formId);
+
+  // No responses yet — skip the AI call entirely
+  if (sessions.length === 0) {
+    return { summary: "", sentiment: "", responseCount: 0 };
+  }
+
   const messages = await getFormMessages(formId);
 
   const prompt = getFormSummaryPrompt(sessions, messages);

--- a/src/components/results/form-results-panel.tsx
+++ b/src/components/results/form-results-panel.tsx
@@ -140,7 +140,8 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
       a.href = url;
       a.download = `responses-${formId.slice(0, 8)}.csv`;
       a.click();
-      URL.revokeObjectURL(url);
+      // Defer revocation so the browser can initiate the download first
+      setTimeout(() => URL.revokeObjectURL(url), 100);
     } catch {
       setError("Failed to export responses");
     }
@@ -260,6 +261,7 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
               <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
               <input
                 type="text"
+                aria-label="Search responses"
                 placeholder="Search responses..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}

--- a/src/components/results/form-summary-panel.tsx
+++ b/src/components/results/form-summary-panel.tsx
@@ -63,10 +63,15 @@ export default function FormSummaryPanel({ formId }: FormSummaryPanelProps) {
     );
   }
 
-  if (!summary) {
+  if (!summary || summary.responseCount === 0) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-sm text-muted-foreground">No summary data available</p>
+        <div className="text-center">
+          <p className="text-sm font-medium text-foreground">No responses yet</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            The AI summary will appear once people complete your form.
+          </p>
+        </div>
       </div>
     );
   }

--- a/src/components/settings/form-setting-panel.tsx
+++ b/src/components/settings/form-setting-panel.tsx
@@ -66,7 +66,7 @@ export default function FormSettingsPanel({
       JSON.stringify(settings) !== JSON.stringify(originalSettings);
     setHasChanges(hasUnsavedChanges);
     onHasChanges?.(hasUnsavedChanges);
-  }, [settings, originalSettings]);
+  }, [settings, originalSettings, onHasChanges]);
 
   const handleInputChange = (
     field: keyof FormSettings,


### PR DESCRIPTION
## Summary
- Fix `URL.revokeObjectURL` being called synchronously before the download starts (could silently fail in some browsers)
- Short-circuit `getOverallSummary` when no responses exist — avoids a wasted AI API call and shows a clear empty state
- Fix missing `onHasChanges` in `useEffect` dependency array (React lint warning)
- Add `aria-label` to search input in results panel

## Test plan
- [x] TypeScript compiles clean
- [x] All 13 E2E tests pass
- [ ] Verify CSV export downloads correctly
- [ ] Verify Summary tab shows "No responses yet" message on a new form