### PR TITLE
Quick open/close toggle on dashboard form cards

### DIFF
--- a/src/actions/form-management.ts
+++ b/src/actions/form-management.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { getSession } from "auth";
-import { createForm, deleteForm, duplicateForm, updateForm } from "@/db/storage";
+import { createForm, deleteForm, duplicateForm, getForm, updateForm } from "@/db/storage";
 import { revalidatePath } from "next/cache";
 import { formTemplates } from "@/lib/form-templates";
 import { FormSettingsInsert } from "@/db/schema";
@@ -43,6 +43,31 @@ export async function createFormFromTemplateAction(templateId: string) {
 
   revalidatePath("/dashboard");
   return form;
+}
+
+export async function toggleFormStatusAction(formId: string) {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const form = await getForm(formId);
+  if (!form || form.userId !== session.user.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const isCurrentlyClosed =
+    form.status === "closed" ||
+    (form.closedAt != null && new Date(form.closedAt) <= new Date());
+
+  if (isCurrentlyClosed) {
+    await updateForm(formId, { ...form, status: "open", closedAt: null }, session.user.id);
+  } else {
+    await updateForm(formId, { ...form, status: "closed" }, session.user.id);
+  }
+
+  revalidatePath("/dashboard");
+  return { newStatus: isCurrentlyClosed ? "open" : "closed" };
 }
 
 export async function updateFormSettingsAction(

--- a/src/app/dashboard/client.tsx
+++ b/src/app/dashboard/client.tsx
@@ -15,13 +15,17 @@ import {
   ArrowUpDown,
   Files,
   Loader2,
+  Lock,
+  Unlock,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { formatDistanceToNow } from "date-fns";
-import { deleteFormAction, duplicateFormAction } from "@/actions/form-management";
+import { deleteFormAction, duplicateFormAction, toggleFormStatusAction } from "@/actions/form-management";
 import { toast } from "sonner";
 import { MAX_FORMS_PER_USER } from "@/lib/constants";
+
+const STORAGE_KEY = "dashboard_response_counts";
 
 type FormWithCount = FormSettings & { responseCount: number };
 
@@ -38,10 +42,9 @@ export default function DashboardClientPage({
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<"newest" | "oldest" | "responses" | "title">("newest");
-
-  const STORAGE_KEY = "dashboard_response_counts";
 
   const getNewResponseCounts = useCallback(() => {
     try {
@@ -144,6 +147,23 @@ export default function DashboardClientPage({
     setConfirmDeleteId(null);
   };
 
+  const handleToggleStatus = async (e: React.MouseEvent, form: FormWithCount) => {
+    e.stopPropagation();
+    setTogglingId(form.id);
+    const isCurrentlyClosed =
+      form.status === "closed" ||
+      (form.closedAt != null && new Date(form.closedAt) <= new Date());
+    try {
+      await toggleFormStatusAction(form.id);
+      toast.success(isCurrentlyClosed ? "Form reopened" : "Form closed");
+      router.refresh();
+    } catch {
+      toast.error("Failed to update form status");
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
   const handleDuplicate = async (e: React.MouseEvent, formId: string) => {
     e.stopPropagation();
     setDuplicatingId(formId);
@@ -200,6 +220,7 @@ export default function DashboardClientPage({
             <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
             <input
               type="text"
+              aria-label="Search forms"
               placeholder="Search forms..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -371,6 +392,27 @@ export default function DashboardClientPage({
                         <Files size={14} />
                       )}
                     </button>
+                    {(() => {
+                      const isCurrentlyClosed =
+                        form.status === "closed" ||
+                        (form.closedAt != null && new Date(form.closedAt) <= new Date());
+                      return (
+                        <button
+                          onClick={(e) => handleToggleStatus(e, form)}
+                          disabled={togglingId === form.id}
+                          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-50"
+                          title={isCurrentlyClosed ? "Reopen form" : "Close form"}
+                        >
+                          {togglingId === form.id ? (
+                            <Loader2 size={14} className="animate-spin" />
+                          ) : isCurrentlyClosed ? (
+                            <Unlock size={14} />
+                          ) : (
+                            <Lock size={14} />
+                          )}
+                        </button>
+                      );
+                    })()}
                     <button
                       onClick={(e) => handleDeleteClick(e, form.id)}
                       className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-destructive transition-colors"

--- a/src/hooks/use-form-settings.ts
+++ b/src/hooks/use-form-settings.ts
@@ -33,7 +33,7 @@ export function useFormSettings(
       };
       fetchFormSettings();
     }
-  }, [initialized]);
+  }, [formId, initialized]);
 
   // Extract form settings from assistant messages
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add a `toggleFormStatusAction` server action that flips a form between open and closed states (when reopening, clears `closedAt` to prevent a previous scheduled closure from re-triggering)
- Add Lock/Unlock toggle button to each dashboard form card — no need to enter the Settings panel just to stop accepting responses
- Move `STORAGE_KEY` to module level in the dashboard client
- Add `aria-label` to dashboard search input
- Fix missing `formId` dependency in `use-form-settings` useEffect

## Test plan
- [x] TypeScript compiles clean
- [x] All 13 E2E tests pass
- [ ] Verify Lock button closes a form (card shows "Closed" badge)
- [ ] Verify Unlock button reopens a form (badge disappears)
- [ ] Verify closed form shows "no longer accepting responses" page