### PR TITLE
Cmd+S save shortcut, fix stale closure, and clean up generic

### DIFF
--- a/src/components/builder/form-builder-chat.tsx
+++ b/src/components/builder/form-builder-chat.tsx
@@ -30,8 +30,8 @@ export default function FormBuilderChat({
   onMessagesUpdate,
   onDetailedView = () => {},
 }: FormBuilderClientProps) {
-  const { messages, isLoading, error, clearError, handleSubmit } = useChat<FormResponse>({
-    sendMessage: async (formId, message) => {
+  const { messages, isLoading, error, clearError, handleSubmit } = useChat({
+    sendMessage: async (formId: string, message: Message) => {
       const newMessages = (await sendMessage(formId, message)) as ExtendedMessage[];
       if (onMessagesUpdate) {
         onMessagesUpdate(newMessages);

--- a/src/components/form-assistant-client.tsx
+++ b/src/components/form-assistant-client.tsx
@@ -43,7 +43,7 @@ export default function FormAssistantClient({
   const [progress, setProgress] = useState(0);
   const [allMessages, setAllMessages] = useState<ExtendedMessage[]>([]);
 
-  const { messages, isLoading, error, clearError, handleSubmit } = useChat<FormAssistantResponse>({
+  const { messages, isLoading, error, clearError, handleSubmit } = useChat({
     sendMessage: async (formId: string, message: Message): Promise<Message[]> => {
       if (!sessionId) throw new Error("Session not initialized");
 
@@ -145,15 +145,7 @@ export default function FormAssistantClient({
     handleSubmit(fakeEvent);
   };
 
-  // Auto-start with prefilled message from URL params
-  useEffect(() => {
-    if (prefillMessage && !prefillUsed && !started) {
-      setPrefillUsed(true);
-      handleStartWithMessage(prefillMessage);
-    }
-  }, [prefillMessage, prefillUsed, started]);
-
-  const handleStartWithMessage = async (msg: string) => {
+  const handleStartWithMessage = useCallback(async (msg: string) => {
     let sid = sessionId;
     if (!sid) {
       const newSession = await createFormSessionAction(formId);
@@ -170,7 +162,15 @@ export default function FormAssistantClient({
       target: { elements: { 0: { value: msg } } },
     } as unknown as React.FormEvent<HTMLFormElement>;
     handleSubmit(fakeEvent);
-  };
+  }, [sessionId, formId, handleSubmit]);
+
+  // Auto-start with prefilled message from URL params
+  useEffect(() => {
+    if (prefillMessage && !prefillUsed && !started) {
+      setPrefillUsed(true);
+      handleStartWithMessage(prefillMessage);
+    }
+  }, [prefillMessage, prefillUsed, started, handleStartWithMessage]);
 
   useEffect(() => {
     if (!isLoading && userMessage) {

--- a/src/components/settings/form-setting-panel.tsx
+++ b/src/components/settings/form-setting-panel.tsx
@@ -1,5 +1,5 @@
 import { FormSettings } from "@/components/builder/types";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   Save,
   Plus,
@@ -55,6 +55,7 @@ export default function FormSettingsPanel({
     useState<FormSettings>(formSettings);
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
 
   useEffect(() => {
     setSettings(formSettings);
@@ -109,7 +110,7 @@ export default function FormSettingsPanel({
     return null;
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
 
     const validationError = validateSettings();
@@ -137,7 +138,19 @@ export default function FormSettingsPanel({
     } finally {
       setIsSaving(false);
     }
-  };
+  }, [settings, onSettingsUpdate, validateSettings]);
+
+  // Cmd+S / Ctrl+S keyboard shortcut to save settings
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s" && hasChanges && !isSaving) {
+        e.preventDefault();
+        formRef.current?.requestSubmit();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [hasChanges, isSaving]);
 
   const handleDiscardChanges = () => {
     setSettings(originalSettings);
@@ -165,7 +178,7 @@ export default function FormSettingsPanel({
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form ref={formRef} onSubmit={handleSubmit} className="space-y-6">
           {/* Basic Information */}
           <section className="rounded-lg border border-border bg-surface p-5">
             <h2 className="mb-4 flex items-center gap-2 text-sm font-medium text-foreground">

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -35,17 +35,17 @@ function abortableWait(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
-export type ChatOptions<TResponse> = {
+export type ChatOptions = {
   sendMessage: (formId: string, message: Message) => Promise<Message[]>;
   formId: string;
   initialMessages?: Message[];
 };
 
-export function useChat<TResponse>({
+export function useChat({
   sendMessage,
   formId,
   initialMessages = [],
-}: ChatOptions<TResponse>) {
+}: ChatOptions) {
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- Add Cmd+S / Ctrl+S keyboard shortcut to save settings in the settings panel (only triggers when there are unsaved changes)
- Fix stale closure in form-assistant-client: move `handleStartWithMessage` before the useEffect that calls it, wrap with `useCallback`, and add it to deps
- Remove unused `TResponse` generic from `useChat` hook

## Test plan
- [x] TypeScript compiles clean
- [x] All 13 E2E tests pass
- [ ] Verify Cmd+S saves settings panel without clicking Save button
- [ ] Verify Cmd+S does nothing when no unsaved changes