### PR TITLE
email template XSS hardening and metadata polish

### DIFF
--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -14,7 +14,12 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { id } = await params;
   const form = await getForm(id);
-  return { title: form?.title || "Form Builder" };
+  const title = form?.title || "Form Builder";
+  return {
+    title,
+    description: form ? `Build and manage your "${title}" conversational form.` : undefined,
+    robots: { index: false },
+  };
 }
 
 export default async function FormBuilderPage({

--- a/src/app/dashboard/new/page.tsx
+++ b/src/app/dashboard/new/page.tsx
@@ -9,6 +9,7 @@ export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Create Form",
+  robots: { index: false },
 };
 
 export default async function NewFormPage() {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { getUserForms } from "@/db/storage";
 
 export const metadata: Metadata = {
   title: "Dashboard",
+  robots: { index: false },
 };
 
 export default async function DashboardPage({

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -5,6 +5,16 @@ const resend = process.env.RESEND_API_KEY
   : null;
 
 const FROM_EMAIL = process.env.EMAIL_FROM || "Chat Forms <noreply@chatforms.app>";
+const APP_URL = process.env.NEXTAUTH_URL || "https://chatforms.app";
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
 
 export async function sendResponseNotification({
   to,
@@ -21,6 +31,11 @@ export async function sendResponseNotification({
 }) {
   if (!resend) return;
 
+  const safeTitle = escapeHtml(formTitle);
+  const safeSummary = escapeHtml(quickSummary);
+  const safeSentiment = escapeHtml(sentiment);
+  const dashboardUrl = `${APP_URL}/dashboard/${formId}#results`;
+
   try {
     await resend.emails.send({
       from: FROM_EMAIL,
@@ -32,16 +47,19 @@ export async function sendResponseNotification({
             New form response
           </h2>
           <p style="font-size: 14px; color: #666; margin: 0 0 20px;">
-            Someone completed <strong>${formTitle}</strong>
+            Someone completed <strong>${safeTitle}</strong>
           </p>
           <div style="background: #f8f9fa; border-radius: 8px; padding: 16px; margin: 0 0 16px;">
             <p style="font-size: 13px; color: #888; margin: 0 0 4px;">Summary</p>
-            <p style="font-size: 14px; color: #111; margin: 0;">${quickSummary}</p>
+            <p style="font-size: 14px; color: #111; margin: 0;">${safeSummary}</p>
           </div>
           <div style="background: #f8f9fa; border-radius: 8px; padding: 16px; margin: 0 0 20px;">
             <p style="font-size: 13px; color: #888; margin: 0 0 4px;">Sentiment</p>
-            <p style="font-size: 14px; color: #111; margin: 0;">${sentiment}</p>
+            <p style="font-size: 14px; color: #111; margin: 0;">${safeSentiment}</p>
           </div>
+          <a href="${dashboardUrl}" style="display: inline-block; background: #4f46e5; color: #fff; font-size: 14px; font-weight: 500; padding: 10px 20px; border-radius: 8px; text-decoration: none; margin: 0 0 20px;">
+            View response
+          </a>
           <p style="font-size: 12px; color: #999; margin: 0;">
             You received this because you have email notifications enabled for this form.
           </p>


### PR DESCRIPTION
## Summary

- Escape HTML in email notification template (form title, summary, sentiment) to prevent XSS injection via form data
- Add `APP_URL` constant from `NEXTAUTH_URL` env var and include a "View response" CTA link in notification emails
- Enrich form builder `generateMetadata` with form-specific description
- Add `robots: noindex` to all authenticated dashboard pages to prevent accidental indexing

## Test plan

- [ ] Send a test notification email and confirm "View response" button links to correct dashboard URL
- [ ] Verify form title with HTML characters (e.g. `<script>`) renders safely as plain text in email client
- [ ] Check browser tab title shows form name when on builder page
- [ ] Confirm `/dashboard` and `/dashboard/[id]` return `X-Robots-Tag: noindex` headers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email notifications now include a direct link to view form responses on the dashboard.

* **Security**
  * Enhanced HTML sanitization in email communications to prevent injection vulnerabilities.

* **Search Engine Optimization**
  * Dashboard pages are now excluded from search engine indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->