### PR TITLE
correctness fixes: duplicate form, auth hardening, closed form UX, webhook validation

### DIFF
--- a/src/actions/form-management.ts
+++ b/src/actions/form-management.ts
@@ -79,5 +79,16 @@ export async function updateFormSettingsAction(
     throw new Error("Unauthorized");
   }
 
+  if (settings.webhookUrl) {
+    try {
+      const parsed = new URL(settings.webhookUrl);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error("Webhook URL must use http or https.");
+      }
+    } catch {
+      throw new Error("Webhook URL must be a valid http or https URL.");
+    }
+  }
+
   return updateForm(formId, settings, session.user.id);
 }

--- a/src/actions/form-results.ts
+++ b/src/actions/form-results.ts
@@ -117,14 +117,14 @@ export async function getFormSessionDetails(
     if (!session) return null;
 
     // Verify the session's form belongs to the current user
-    if (session.formId) {
-      const [form] = await db
-        .select({ userId: forms.userId })
-        .from(forms)
-        .where(eq(forms.id, session.formId));
-      if (!form || form.userId !== userSession.user.id) {
-        throw new Error("Unauthorized");
-      }
+    if (!session.formId) throw new Error("Unauthorized");
+
+    const [form] = await db
+      .select({ userId: forms.userId })
+      .from(forms)
+      .where(eq(forms.id, session.formId));
+    if (!form || form.userId !== userSession.user.id) {
+      throw new Error("Unauthorized");
     }
 
     return session;

--- a/src/app/forms/[id]/page.tsx
+++ b/src/app/forms/[id]/page.tsx
@@ -42,9 +42,9 @@ export default async function FormPage({
     notFound();
   }
 
-  const accepting = await isFormAcceptingResponses(id);
+  const { accepting, reason } = await isFormAcceptingResponses(id);
   if (!accepting) {
-    return <FormClosedPage title={formSettings.title} />;
+    return <FormClosedPage title={formSettings.title} reason={reason} />;
   }
 
   const accentColor = formSettings.accentColor;

--- a/src/components/form-closed.tsx
+++ b/src/components/form-closed.tsx
@@ -1,6 +1,34 @@
-import { MessageSquareText, Lock } from "lucide-react";
+import { MessageSquareText, Lock, CheckCircle2 } from "lucide-react";
+import type { FormClosedReason } from "@/db/storage";
 
-export default function FormClosedPage({ title }: { title: string }) {
+const REASON_CONTENT: Record<
+  FormClosedReason,
+  { heading: string; body: string }
+> = {
+  closed: {
+    heading: "This form is no longer accepting responses",
+    body: "The form owner has closed this form. If you believe this is an error, please contact the person who shared it with you.",
+  },
+  scheduled: {
+    heading: "This form is no longer accepting responses",
+    body: "This form's submission window has ended. If you believe this is an error, please contact the person who shared it with you.",
+  },
+  max_responses: {
+    heading: "This form has reached its response limit",
+    body: "The maximum number of responses has been collected. Thank you for your interest — no further submissions are being accepted.",
+  },
+};
+
+export default function FormClosedPage({
+  title,
+  reason = "closed",
+}: {
+  title: string;
+  reason?: FormClosedReason;
+}) {
+  const { heading, body } = REASON_CONTENT[reason];
+  const isMaxResponses = reason === "max_responses";
+
   return (
     <div className="flex h-full flex-col bg-background overflow-hidden">
       <header className="flex h-14 items-center border-b border-border bg-surface px-6 shrink-0">
@@ -13,29 +41,24 @@ export default function FormClosedPage({ title }: { title: string }) {
       <div className="flex-1 flex flex-col items-center justify-center px-6 py-8">
         <div className="w-full max-w-md text-center space-y-4">
           <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-muted">
-            <Lock size={24} className="text-muted-foreground" />
+            {isMaxResponses ? (
+              <CheckCircle2 size={24} className="text-muted-foreground" />
+            ) : (
+              <Lock size={24} className="text-muted-foreground" />
+            )}
           </div>
           <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
             {title}
           </p>
-          <h1 className="text-xl font-semibold text-foreground">
-            This form is no longer accepting responses
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            The form owner has closed this form or it has reached its response
-            limit. If you believe this is an error, please contact the person
-            who shared this form with you.
-          </p>
+          <h1 className="text-xl font-semibold text-foreground">{heading}</h1>
+          <p className="text-sm text-muted-foreground">{body}</p>
         </div>
       </div>
 
       <footer className="border-t border-border bg-surface px-6 py-3 text-center shrink-0">
         <p className="text-[10px] text-muted-foreground">
           Powered by{" "}
-          <a
-            href="/"
-            className="font-medium text-accent hover:underline"
-          >
+          <a href="/" className="font-medium text-accent hover:underline">
             Chat Forms
           </a>
         </p>

--- a/src/components/settings/form-setting-panel.tsx
+++ b/src/components/settings/form-setting-panel.tsx
@@ -97,7 +97,10 @@ export default function FormSettingsPanel({
     }
     if (settings.webhookUrl) {
       try {
-        new URL(settings.webhookUrl);
+        const parsed = new URL(settings.webhookUrl);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          return "Webhook URL must use http or https (e.g., https://example.com/webhook).";
+        }
       } catch {
         return "Webhook URL must be a valid URL (e.g., https://example.com/webhook).";
       }

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -164,6 +164,9 @@ export const duplicateForm = async (id: string, userId: string) => {
       callToAction: original.callToAction,
       endScreenMessage: original.endScreenMessage,
       accentColor: original.accentColor,
+      maxResponses: original.maxResponses,
+      webhookUrl: original.webhookUrl,
+      emailNotifications: original.emailNotifications,
       userId,
     })
     .returning();
@@ -184,24 +187,32 @@ export const getFormResponseCount = async (formId: string) => {
   return result?.count ?? 0;
 };
 
-export const isFormAcceptingResponses = async (formId: string) => {
+export type FormClosedReason = "closed" | "scheduled" | "max_responses";
+
+export const isFormAcceptingResponses = async (
+  formId: string
+): Promise<{ accepting: boolean; reason?: FormClosedReason }> => {
   if (!db) {
     throw new Error("Database not initialized");
   }
 
   const form = await getForm(formId);
-  if (!form) return false;
+  if (!form) return { accepting: false, reason: "closed" };
 
-  if (form.status === "closed") return false;
+  if (form.status === "closed") return { accepting: false, reason: "closed" };
 
-  if (form.closedAt && new Date(form.closedAt) <= new Date()) return false;
+  if (form.closedAt && new Date(form.closedAt) <= new Date()) {
+    return { accepting: false, reason: "scheduled" };
+  }
 
   if (form.maxResponses) {
     const responseCount = await getFormResponseCount(formId);
-    if (responseCount >= form.maxResponses) return false;
+    if (responseCount >= form.maxResponses) {
+      return { accepting: false, reason: "max_responses" };
+    }
   }
 
-  return true;
+  return { accepting: true };
 };
 
 export const updateForm = async (


### PR DESCRIPTION
## Summary

- **Fix `duplicateForm`**: copies `maxResponses`, `webhookUrl`, and `emailNotifications` — previously these were silently dropped on duplication
- **Harden auth**: `getFormSessionDetails` now throws `Unauthorized` when `formId` is null rather than skipping the ownership check
- **Improved closed-form UX**: `isFormAcceptingResponses` returns `{ accepting, reason }` ("closed" | "scheduled" | "max_responses"); `FormClosedPage` shows context-specific headings and body text
- **Webhook URL validation**: requires `http:` or `https:` protocol at both client (settings panel) and server (`updateFormSettingsAction`), preventing malformed URLs from reaching storage

## Test plan

- [ ] Duplicate a form with webhook URL and max responses set — confirm both are copied
- [ ] Try saving a form with `ftp://example.com` as webhook URL — confirm error shown in UI
- [ ] Close a form manually → confirm "The form owner has closed this form" message
- [ ] Set `maxResponses = 1`, submit once → confirm "This form has reached its response limit" message on second visit
- [ ] Confirm `getFormSessionDetails` returns 500/Unauthorized for a session with null formId