### PR TITLE
resilience: session cap, webhook retry, and prefill URL builder

### DIFF
--- a/src/actions/form-assistant.ts
+++ b/src/actions/form-assistant.ts
@@ -21,6 +21,7 @@ import { withAIErrorHandling } from "@/lib/ai-utils";
 import { sendResponseNotification } from "@/lib/email";
 import { headers } from "next/headers";
 import { rateLimit } from "@/lib/rate-limit";
+import { MAX_SESSION_MESSAGES } from "@/lib/constants";
 
 // Type for the form response
 export type FormAssistantResponse = z.infer<typeof formAssistantResponseSchema>;
@@ -76,6 +77,9 @@ export async function sendMessage(
   }
 
   const messages = await getFormSessionMessages(sessionId);
+  if (messages.length >= MAX_SESSION_MESSAGES) {
+    throw new Error("This session has reached its message limit. Please start a new form.");
+  }
   const newMessages: ExtendedMessage[] = [...messages, message];
 
   await addFormSessionMessages(sessionId, [message]);

--- a/src/components/sharing/form-sharing-panel.tsx
+++ b/src/components/sharing/form-sharing-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Check, Copy, Link as LinkIcon, QrCode, Code2, Download } from "lucide-react";
+import { Check, Copy, Link as LinkIcon, QrCode, Code2, Download, Zap } from "lucide-react";
 import QRCode from "qrcode";
 
 interface FormSharingPanelProps {
@@ -12,10 +12,14 @@ export default function FormSharingPanel({ formId }: FormSharingPanelProps) {
   const [copied, setCopied] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [embedHeight, setEmbedHeight] = useState(600);
+  const [prefillMsg, setPrefillMsg] = useState("");
 
   const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
   const formUrl = `${baseUrl}/forms/${formId}`;
   const embedCode = `<iframe src="${formUrl}" width="100%" height="${embedHeight}" frameborder="0" style="border:none;border-radius:12px;"></iframe>`;
+  const prefillUrl = prefillMsg.trim()
+    ? `${formUrl}?msg=${encodeURIComponent(prefillMsg.trim())}`
+    : "";
 
   useEffect(() => {
     if (formUrl && baseUrl) {
@@ -134,6 +138,42 @@ export default function FormSharingPanel({ formId }: FormSharingPanelProps) {
           <p className="mt-1.5 text-[10px] text-muted-foreground">
             Paste this HTML into your website to embed the form.
           </p>
+        </section>
+
+        {/* Prefill Link */}
+        <section>
+          <div className="flex items-center gap-2 mb-2">
+            <Zap size={14} className="text-muted-foreground" />
+            <h3 className="text-xs font-medium text-foreground">Prefill Link</h3>
+          </div>
+          <p className="text-[10px] text-muted-foreground mb-2">
+            Add an opening message so the form starts right away when someone opens the link.
+          </p>
+          <input
+            type="text"
+            value={prefillMsg}
+            onChange={(e) => setPrefillMsg(e.target.value)}
+            placeholder="e.g. I'm interested in your product..."
+            maxLength={200}
+            className="w-full rounded-md border border-border bg-surface px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground mb-2"
+          />
+          {prefillUrl && (
+            <div className="flex gap-2">
+              <input
+                type="text"
+                readOnly
+                value={prefillUrl}
+                className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-xs text-foreground font-mono"
+              />
+              <button
+                onClick={() => copyToClipboard(prefillUrl, "prefill")}
+                className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-3 py-2 text-xs font-medium text-foreground hover:bg-surface-hover transition-colors"
+              >
+                {copied === "prefill" ? <Check size={12} className="text-success" /> : <Copy size={12} />}
+                {copied === "prefill" ? "Copied" : "Copy"}
+              </button>
+            </div>
+          )}
         </section>
       </div>
     </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,6 @@
 export const MAX_FORMS_PER_USER = 10;
 
+export const MAX_SESSION_MESSAGES = 40;
+
 export const INITIAL_BUILDER_MESSAGE =
   "Let's start creating the form. Give me an idea of what is form created for?";

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -10,25 +10,41 @@ interface WebhookPayload {
   structuredAnswers: StructuredAnswer[];
 }
 
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAYS = [1000, 2000];
+
+async function attemptWebhook(webhookUrl: string, body: string): Promise<boolean> {
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    signal: AbortSignal.timeout(10000),
+  });
+  return response.ok;
+}
+
 export async function fireWebhook(
   webhookUrl: string,
   payload: WebhookPayload
 ): Promise<void> {
-  try {
-    const response = await fetch(webhookUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      signal: AbortSignal.timeout(10000),
-    });
+  const body = JSON.stringify(payload);
 
-    if (!response.ok) {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const ok = await attemptWebhook(webhookUrl, body);
+      if (ok) return;
       console.error(
-        `Webhook failed: ${response.status} ${response.statusText} for ${webhookUrl}`
+        `Webhook attempt ${attempt}/${MAX_ATTEMPTS} failed (non-OK status) for ${webhookUrl}`
+      );
+    } catch (error) {
+      console.error(
+        `Webhook attempt ${attempt}/${MAX_ATTEMPTS} error for ${webhookUrl}:`,
+        error
       );
     }
-  } catch (error) {
-    // Log but don't throw — webhook failures shouldn't break the form flow
-    console.error(`Webhook error for ${webhookUrl}:`, error);
+
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAYS[attempt - 1]));
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **Session message cap**: `MAX_SESSION_MESSAGES = 40` enforced in `sendMessage()` — prevents runaway conversations and controls AI costs; throws a clear error if exceeded
- **Webhook retry**: `fireWebhook` now retries up to 3 times with 1s/2s backoff delays before giving up; logs each failed attempt with attempt number
- **Prefill URL builder**: new section in the sharing panel — type an opening message and get a `?msg=...` link that auto-starts the form; the form assistant already handles this param

## Test plan

- [ ] Submit 40 messages in a single session → confirm "reached message limit" error on the 41st
- [ ] Set webhook to a URL that returns 5xx → confirm retry attempts are logged (check server logs)
- [ ] In sharing panel, type a prefill message → confirm URL updates live and copies correctly
- [ ] Open a `?msg=` link → confirm form auto-starts with the pre-filled message