### PR TITLE
analytics: accurate response counts, last response time, date range filter

### DIFF
--- a/src/app/dashboard/client.tsx
+++ b/src/app/dashboard/client.tsx
@@ -27,7 +27,7 @@ import { MAX_FORMS_PER_USER } from "@/lib/constants";
 
 const STORAGE_KEY = "dashboard_response_counts";
 
-type FormWithCount = FormSettings & { responseCount: number };
+type FormWithCount = FormSettings & { responseCount: number; lastResponseAt: Date | null };
 
 export default function DashboardClientPage({
   forms,
@@ -333,13 +333,21 @@ export default function DashboardClientPage({
                       {form.expectedCompletionTime}
                     </span>
                   )}
-                  {form.createdAt && (
+                  {form.lastResponseAt ? (
                     <span className="shrink-0">
+                      Last response{" "}
+                      {formatDistanceToNow(new Date(form.lastResponseAt), {
+                        addSuffix: true,
+                      })}
+                    </span>
+                  ) : form.createdAt ? (
+                    <span className="shrink-0">
+                      Created{" "}
                       {formatDistanceToNow(new Date(form.createdAt), {
                         addSuffix: true,
                       })}
                     </span>
-                  )}
+                  ) : null}
                 </div>
               </div>
 

--- a/src/components/results/form-results-panel.tsx
+++ b/src/components/results/form-results-panel.tsx
@@ -18,6 +18,9 @@ import { formatDistanceToNow } from "date-fns";
 const SENTIMENT_OPTIONS = ["all", "positive", "neutral", "negative"] as const;
 type SentimentFilter = (typeof SENTIMENT_OPTIONS)[number];
 
+const DATE_RANGE_OPTIONS = ["7d", "30d", "90d", "all"] as const;
+type DateRangeFilter = (typeof DATE_RANGE_OPTIONS)[number];
+
 interface FormResultsPanelProps {
   formId: string;
 }
@@ -29,6 +32,7 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [sentimentFilter, setSentimentFilter] = useState<SentimentFilter>("all");
+  const [dateRange, setDateRange] = useState<DateRangeFilter>("all");
   const [analytics, setAnalytics] = useState<FormAnalytics | null>(null);
   const [mobileShowDetail, setMobileShowDetail] = useState(false);
 
@@ -49,6 +53,15 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
   const filteredSessions = useMemo(() => {
     let filtered = sessions;
 
+    if (dateRange !== "all") {
+      const days = parseInt(dateRange);
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - days);
+      filtered = filtered.filter(
+        (s) => s.createdAt && new Date(s.createdAt) >= cutoff
+      );
+    }
+
     if (searchQuery.trim()) {
       const q = searchQuery.toLowerCase();
       filtered = filtered.filter(
@@ -65,7 +78,7 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
     }
 
     return filtered;
-  }, [sessions, searchQuery, sentimentFilter]);
+  }, [sessions, searchQuery, sentimentFilter, dateRange]);
 
   const fetchSessions = async () => {
     setLoading(true);
@@ -277,20 +290,38 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
                 </button>
               )}
             </div>
-            <div className="flex gap-1">
-              {SENTIMENT_OPTIONS.map((option) => (
-                <button
-                  key={option}
-                  onClick={() => setSentimentFilter(option)}
-                  className={`rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors ${
-                    sentimentFilter === option
-                      ? "bg-accent text-accent-foreground"
-                      : "bg-muted text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  {option === "all" ? "All" : option.charAt(0).toUpperCase() + option.slice(1)}
-                </button>
-              ))}
+            <div className="flex items-center gap-2">
+              <div className="flex gap-1">
+                {DATE_RANGE_OPTIONS.map((option) => (
+                  <button
+                    key={option}
+                    onClick={() => setDateRange(option)}
+                    className={`rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      dateRange === option
+                        ? "bg-accent text-accent-foreground"
+                        : "bg-muted text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {option === "all" ? "All time" : option}
+                  </button>
+                ))}
+              </div>
+              <div className="w-px h-3 bg-border" />
+              <div className="flex gap-1">
+                {SENTIMENT_OPTIONS.map((option) => (
+                  <button
+                    key={option}
+                    onClick={() => setSentimentFilter(option)}
+                    className={`rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      sentimentFilter === option
+                        ? "bg-accent text-accent-foreground"
+                        : "bg-muted text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {option === "all" ? "All" : option.charAt(0).toUpperCase() + option.slice(1)}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
 

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -10,7 +10,7 @@ import {
   users,
 } from "@/db/schema";
 import { db } from "@/db/db";
-import { and, count, desc, eq, gte, lte } from "drizzle-orm";
+import { and, count, desc, eq, gte, lte, max } from "drizzle-orm";
 import { FormAssistantResponse } from "@/actions/form-assistant";
 import { MAX_FORMS_PER_USER } from "@/lib/constants";
 
@@ -105,7 +105,8 @@ export const getUserForms = async (userId: string) => {
       emailNotifications: forms.emailNotifications,
       createdAt: forms.createdAt,
       userId: forms.userId,
-      responseCount: count(formSessions.id),
+      responseCount: count(formSessions.completedAt),
+      lastResponseAt: max(formSessions.completedAt),
     })
     .from(forms)
     .leftJoin(formSessions, eq(forms.id, formSessions.formId))


### PR DESCRIPTION
## Summary

- **Fix response count**: `getUserForms` now uses `count(completedAt)` to count only sessions that were actually completed — previously counted all session rows including abandoned ones, over-reporting responses
- **Last response timestamp**: dashboard form cards now show "Last response X ago" when responses exist, falling back to "Created X ago" for forms with no responses yet
- **Date range filter**: results panel now has 7d / 30d / 90d / All time filter chips alongside the existing sentiment filter

## Test plan

- [ ] Start a form session but don't complete it → confirm dashboard card count stays at 0
- [ ] Complete a session → confirm dashboard count increments and "Last response X ago" appears
- [ ] In results panel, use date filters to verify sessions outside the range are hidden
- [ ] Verify filter resets work correctly when switching between ranges