### PR TITLE
SEO metadata, lazy preview sessions, analytics accuracy, and key themes

### DIFF
--- a/src/actions/form-results.ts
+++ b/src/actions/form-results.ts
@@ -198,7 +198,12 @@ export async function getFormAnalytics(formId: string): Promise<FormAnalytics> {
       `.as("avg_seconds"),
     })
     .from(formSessions)
-    .where(eq(formSessions.formId, formId));
+    .where(
+      and(
+        eq(formSessions.formId, formId),
+        sql`json_array_length(${formSessions.messageHistory}) > 0`
+      )
+    );
 
   const sentimentRows: { sentiment: string | null; count: number }[] = await db
     .select({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,27 @@
+import type { Metadata } from "next";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { authOptions } from "auth";
 import { ArrowRight, MessageSquareText, Zap, BarChart3 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Chat Forms — AI-powered conversational forms",
+  description:
+    "Build interactive forms with AI. Your respondents chat naturally instead of filling out fields. Higher completion rates, richer data, better experience.",
+  openGraph: {
+    title: "Chat Forms — AI-powered conversational forms",
+    description:
+      "Build interactive forms with AI. Your respondents chat naturally instead of filling out fields.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Chat Forms — AI-powered conversational forms",
+    description:
+      "Build interactive forms with AI. Your respondents chat naturally instead of filling out fields.",
+  },
+};
 
 export default async function HomePage() {
   const session = await getServerSession(authOptions);

--- a/src/components/form-builder-client.tsx
+++ b/src/components/form-builder-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Message } from "@ai-sdk/react";
-import { useState, useEffect, useCallback, useRef } from "react";
-import { MessageCircle, Settings, BarChart3, LineChart, Eye, X, Share2 } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { MessageCircle, Settings, BarChart3, LineChart, Eye, Share2, X } from "lucide-react";
 import FormBuilderChat from "./builder/form-builder-chat";
 import Header from "./builder/header";
 import { useFormSettings } from "@/hooks/use-form-settings";
@@ -10,7 +10,6 @@ import FormSettingsPanel from "./settings/form-setting-panel";
 import { FormSettings } from "./builder/types";
 import { Toaster } from "sonner";
 import FormAssistantClient from "./form-assistant-client";
-import { createFormSessionAction } from "@/actions/form-assistant";
 import FormResultsPanel from "./results/form-results-panel";
 import FormSummaryPanel from "./results/form-summary-panel";
 import FormSharingPanel from "./sharing/form-sharing-panel";
@@ -57,13 +56,7 @@ export default function FormBuilder({
       },
     ]
   );
-  const [formAssistantSessionId, setFormAssistantSessionId] = useState<string | null>(null);
-
-  const resetSession = useCallback(() => {
-    createFormSessionAction(formId).then((newSession) => {
-      setFormAssistantSessionId(newSession.id);
-    });
-  }, [formId]);
+  const [previewKey, setPreviewKey] = useState(0);
 
   const {
     formSettings,
@@ -72,13 +65,6 @@ export default function FormBuilder({
     formSettingsUpdated,
     setFormSettingsUpdated,
   } = useFormSettings(messages, formId);
-
-  // Create a preview session only when form settings first become available
-  useEffect(() => {
-    if (formSettings && !formAssistantSessionId) {
-      resetSession();
-    }
-  }, [formSettings, formAssistantSessionId, resetSession]);
 
   const [copied, setCopied] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
@@ -133,8 +119,7 @@ export default function FormBuilder({
   const confirmReset = () => {
     setShowResetConfirm(false);
     if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
-    setFormAssistantSessionId(null);
-    setTimeout(() => resetSession(), 10);
+    setPreviewKey((k) => k + 1);
   };
 
   const cancelReset = () => {
@@ -189,7 +174,7 @@ export default function FormBuilder({
             ))}
 
             {/* Mobile preview toggle */}
-            {formAssistantSessionId && formSettings && (
+            {formSettings && (
               <button
                 onClick={() => setShowMobilePreview(true)}
                 className="ml-auto flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors md:hidden"
@@ -248,7 +233,7 @@ export default function FormBuilder({
 
         {/* Right panel - form preview (hidden on mobile, shown as overlay) */}
         <div className={`hidden md:block overflow-hidden relative transition-all duration-200 ${activeTab === "results" ? "w-[45%]" : "w-[55%]"}`}>
-          {formAssistantSessionId && formSettings && (
+          {formSettings && (
             <div className="absolute top-3 right-3 z-20">
               {showResetConfirm ? (
                 <div className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1 text-xs">
@@ -276,9 +261,9 @@ export default function FormBuilder({
               )}
             </div>
           )}
-          {formAssistantSessionId && formSettings ? (
+          {formSettings ? (
             <FormAssistantClient
-              sessionId={formAssistantSessionId}
+              key={previewKey}
               formId={formId}
               formSettings={formSettings}
               hideHeader
@@ -330,9 +315,9 @@ export default function FormBuilder({
               </div>
             </div>
             <div className="h-[calc(100%-41px)]">
-              {formAssistantSessionId && formSettings ? (
+              {formSettings ? (
                 <FormAssistantClient
-                  sessionId={formAssistantSessionId}
+                  key={previewKey}
                   formId={formId}
                   formSettings={formSettings}
                   hideHeader

--- a/src/components/results/form-summary-panel.tsx
+++ b/src/components/results/form-summary-panel.tsx
@@ -106,6 +106,20 @@ export default function FormSummaryPanel({ formId }: FormSummaryPanelProps) {
           </div>
         )}
 
+        {summary.keyThemes && summary.keyThemes.length > 0 && (
+          <div className="rounded-lg border border-border bg-surface p-4">
+            <p className="text-xs font-medium text-muted-foreground mb-3">Key Themes</p>
+            <ul className="space-y-1.5">
+              {summary.keyThemes.map((theme, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-foreground">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
+                  {theme}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
         {summary.summary && (
           <div className="rounded-lg border border-border bg-surface p-4">
             <p className="text-xs font-medium text-muted-foreground mb-2">Summary</p>

--- a/src/system-prompts/results.ts
+++ b/src/system-prompts/results.ts
@@ -21,12 +21,16 @@ ${JSON.stringify(sessions)}
 ${JSON.stringify(messages)}
 
 ## Response Format
-Please provide a summary of the form sessions and the overall sentiment of the form.
+Please provide:
+- A concise summary of the form sessions (2-4 sentences).
+- The overall sentiment (e.g. "Mostly positive", "Mixed", "Largely negative").
+- 3-6 key themes that emerged across responses (short phrases, each under 8 words).
 
 ## Response
 {
   "summary": "string",
-  "sentiment": "string"
+  "sentiment": "string",
+  "keyThemes": ["string", ...]
 }
   `;
 }

--- a/src/types/promp-schema.ts
+++ b/src/types/promp-schema.ts
@@ -42,4 +42,5 @@ export const formAssistantResponseSchema = z.object({
 export const formOverallSummarySchema = z.object({
   summary: z.string(),
   sentiment: z.string(),
+  keyThemes: z.array(z.string()),
 });


### PR DESCRIPTION
## Summary
- Add `metadata` export to landing page (`/`) with title, description, OpenGraph, and Twitter card tags — previously the page had no metadata at all
- **Stop pre-creating preview sessions** in the form builder: previously a `formSessions` row was inserted to the DB every time the builder loaded (before the user clicked Start), inflating `totalStarted` analytics and accumulating orphaned rows; now `FormAssistantClient` creates sessions lazily on first start, and "Reset preview" remounts via a `key` counter
- **Fix `totalStarted` in analytics**: add `json_array_length(message_history) > 0` filter so empty sessions (past orphans) don't count as started
- **Add `keyThemes` to overall summary**: `formOverallSummarySchema` gains `keyThemes: string[]`, the prompt requests 3–6 short theme phrases, and `FormSummaryPanel` displays them as a bulleted list above the text summary

## Test plan
- [ ] Visit `/` as a logged-out user — confirm page title is "Chat Forms — AI-powered conversational forms" in browser tab
- [ ] Open a form builder — confirm no new row appears in `formSessions` DB table until you click "Start" in the preview
- [ ] Click "Reset preview" — confirm preview resets to welcome screen without any DB session pre-creation
- [ ] Open Results → Summary for a form with responses — confirm "Key Themes" section appears with bullets
- [ ] Check Results → analytics `totalStarted` — confirm it doesn't count sessions with empty message history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Key Themes section now displays in form results summaries, automatically extracting and presenting the top 3-6 key themes identified from session data.

* **Bug Fixes**
  * Form analytics aggregation now correctly filters to sessions with conversation history, providing more accurate totals and averages.

* **Documentation**
  * Enhanced page metadata for improved search engine visibility and social media preview sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->