### PR TITLE
builder optimizations, UX improvements, and CSV export fix

### DIFF
--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -1,9 +1,13 @@
 import type { Metadata } from "next";
+import { cache } from "react";
 import FormBuilderClient from "@/components/form-builder-client";
-import { getForm, getFormMessages, getFormResponseCount } from "@/db/storage";
+import { getForm, getFormResponseCount } from "@/db/storage";
 import { getSession } from "auth";
 import { redirect } from "next/navigation";
 import { INITIAL_BUILDER_MESSAGE } from "@/lib/constants";
+
+// Deduplicate getForm calls within the same request (generateMetadata + page body)
+const getFormCached = cache(getForm);
 
 export const dynamic = "force-dynamic";
 
@@ -13,7 +17,7 @@ export async function generateMetadata({
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
   const { id } = await params;
-  const form = await getForm(id);
+  const form = await getFormCached(id);
   const title = form?.title || "Form Builder";
   return {
     title,
@@ -34,17 +38,16 @@ export default async function FormBuilderPage({
     redirect("/login");
   }
 
-  // validate form belongs to user
-  const form = await getForm(id);
+  // validate form belongs to user (getFormCached reuses the result from generateMetadata)
+  const form = await getFormCached(id);
   if (form?.userId !== session?.user?.id) {
     redirect("/dashboard");
   }
 
-  const [messages, responseCount] = await Promise.all([
-    getFormMessages(id),
-    getFormResponseCount(id),
-  ]);
+  const responseCount = await getFormResponseCount(id);
 
+  // Inline message extraction from the already-loaded form (avoids a third forms table query)
+  const messages = (form?.messageHistory ?? []).slice(-20);
   if (messages.length === 0) {
     messages.push({
       id: "initial-message",

--- a/src/components/form-assistant-client.tsx
+++ b/src/components/form-assistant-client.tsx
@@ -329,23 +329,38 @@ export default function FormAssistantClient({
           ) : null}
 
           {/* Error state */}
-          {error && (
-            <div role="alert" className="mt-3 flex items-center gap-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
-              <AlertCircle size={16} className="shrink-0 text-destructive" />
-              <p className="flex-1 text-sm text-foreground">
-                {error.toLowerCase().includes("too many requests")
-                  ? "You're sending messages too quickly. Please wait a moment and try again."
-                  : error}
-              </p>
-              <button
-                onClick={clearError}
-                className="inline-flex items-center gap-1 rounded-md bg-surface px-2.5 py-1 text-xs font-medium text-foreground hover:bg-surface-hover transition-colors border border-border"
-              >
-                <RotateCcw size={12} />
-                Retry
-              </button>
-            </div>
-          )}
+          {error && (() => {
+            const isLimitError = error.toLowerCase().includes("message limit");
+            const isRateLimit = error.toLowerCase().includes("too many requests");
+            return (
+              <div role="alert" className="mt-3 flex items-center gap-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
+                <AlertCircle size={16} className="shrink-0 text-destructive" />
+                <p className="flex-1 text-sm text-foreground">
+                  {isLimitError
+                    ? "This session has reached its message limit."
+                    : isRateLimit
+                      ? "You're sending messages too quickly. Please wait a moment and try again."
+                      : error}
+                </p>
+                {isLimitError ? (
+                  <a
+                    href={`/forms/${formId}`}
+                    className="inline-flex items-center gap-1 rounded-md bg-surface px-2.5 py-1 text-xs font-medium text-foreground hover:bg-surface-hover transition-colors border border-border shrink-0"
+                  >
+                    Start new
+                  </a>
+                ) : (
+                  <button
+                    onClick={clearError}
+                    className="inline-flex items-center gap-1 rounded-md bg-surface px-2.5 py-1 text-xs font-medium text-foreground hover:bg-surface-hover transition-colors border border-border shrink-0"
+                  >
+                    <RotateCcw size={12} />
+                    Retry
+                  </button>
+                )}
+              </div>
+            );
+          })()}
         </div>
       </div>
 

--- a/src/components/results/form-results-panel.tsx
+++ b/src/components/results/form-results-panel.tsx
@@ -151,7 +151,7 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
   const handleExport = async () => {
     try {
       const data = await getFormSessionsForExport(formId);
-      const headers = ["Date", "Summary", "Sentiment", "Details", "Structured Answers"];
+      const headers = ["Date", "Summary", "Sentiment", "Details", "Structured Answers", "Flagged", "Reviewed"];
       const rows = data.map((s) => {
         const structuredStr = s.structuredData
           ? s.structuredData.map((a) => `${a.question}: ${a.answer}`).join("; ")
@@ -162,6 +162,8 @@ export default function FormResultsPanel({ formId }: FormResultsPanelProps) {
           s.overallSentiment || "",
           `"${(s.detailedSummary || "").replace(/"/g, '""')}"`,
           `"${structuredStr.replace(/"/g, '""')}"`,
+          s.flagged ? "Yes" : "No",
+          s.reviewed ? "Yes" : "No",
         ];
       });
 

--- a/src/components/settings/form-setting-panel.tsx
+++ b/src/components/settings/form-setting-panel.tsx
@@ -91,7 +91,7 @@ export default function FormSettingsPanel({
     handleInputChange("keyInformation", updatedKeyInformation);
   };
 
-  const validateSettings = (): string | null => {
+  const validateSettings = useCallback((): string | null => {
     if (!settings.title.trim()) {
       return "Form title is required.";
     }
@@ -111,7 +111,7 @@ export default function FormSettingsPanel({
       }
     }
     return null;
-  };
+  }, [settings]);
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- **Reduce builder page DB queries**: use `React.cache` to deduplicate the two `getForm` calls (from `generateMetadata` and the page body) into a single DB query; inline message extraction from the loaded form to eliminate a third `forms` table query
- **Message limit error UX**: detect "message limit" error in `FormAssistantClient` and show a "Start new" link (to `/forms/[formId]`) instead of a Retry button that would always fail
- **CSV export**: add `Flagged` and `Reviewed` columns to the exported CSV so review state is preserved in exports
- **Fix `validateSettings` memoization**: wrap in `useCallback([settings])` so `handleSubmit`'s dependency chain is correctly stable

## Test plan
- [ ] Open a form builder — confirm only 1 DB query to `forms` table on load (check server logs or network)
- [ ] Fill a form conversation to 40 messages — confirm error shows "Start new" link instead of Retry
- [ ] Export responses CSV — confirm `Flagged` and `Reviewed` columns appear with Yes/No values
- [ ] Edit form settings and save — confirm no extra re-renders from `validateSettings` instability

🤖 Generated with [Claude Code](https://claude.com/claude-code)