### PR TITLE
Security: sanitize settings writes + eliminate redundant DB queries

### DIFF
--- a/src/actions/form-management.ts
+++ b/src/actions/form-management.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { getSession } from "auth";
-import { createForm, deleteForm, duplicateForm, getForm, updateForm } from "@/db/storage";
+import { createForm, deleteForm, duplicateForm, getForm, getFormStatusFields, updateForm } from "@/db/storage";
 import { revalidatePath } from "next/cache";
 import { formTemplates } from "@/lib/form-templates";
 import { FormSettingsInsert } from "@/db/schema";
@@ -51,7 +51,7 @@ export async function toggleFormStatusAction(formId: string) {
     throw new Error("Unauthorized");
   }
 
-  const form = await getForm(formId);
+  const form = await getFormStatusFields(formId);
   if (!form || form.userId !== session.user.id) {
     throw new Error("Unauthorized");
   }
@@ -61,9 +61,9 @@ export async function toggleFormStatusAction(formId: string) {
     (form.closedAt != null && new Date(form.closedAt) <= new Date());
 
   if (isCurrentlyClosed) {
-    await updateForm(formId, { ...form, status: "open", closedAt: null }, session.user.id);
+    await updateForm(formId, { status: "open", closedAt: null }, session.user.id);
   } else {
-    await updateForm(formId, { ...form, status: "closed" }, session.user.id);
+    await updateForm(formId, { status: "closed" }, session.user.id);
   }
 
   revalidatePath("/dashboard");
@@ -90,5 +90,27 @@ export async function updateFormSettingsAction(
     }
   }
 
-  return updateForm(formId, settings, session.user.id);
+  // Explicitly pick only safe user-settable fields — prevents accidental
+  // overwrite of messageHistory, userId, id, or createdAt if the caller's
+  // object happens to carry extra DB-only properties at runtime.
+  const safeFields: FormSettingsInsert = {
+    title: settings.title,
+    tone: settings.tone,
+    persona: settings.persona,
+    keyInformation: settings.keyInformation,
+    targetAudience: settings.targetAudience,
+    expectedCompletionTime: settings.expectedCompletionTime,
+    aboutBusiness: settings.aboutBusiness,
+    welcomeMessage: settings.welcomeMessage,
+    callToAction: settings.callToAction,
+    endScreenMessage: settings.endScreenMessage,
+    status: settings.status,
+    closedAt: settings.closedAt,
+    maxResponses: settings.maxResponses,
+    webhookUrl: settings.webhookUrl,
+    accentColor: settings.accentColor,
+    emailNotifications: settings.emailNotifications,
+  };
+
+  return updateForm(formId, safeFields, session.user.id);
 }

--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getForm, getFormResponseCount } from "@/db/storage";
 import { getSession } from "auth";
 import { redirect } from "next/navigation";
 import { INITIAL_BUILDER_MESSAGE } from "@/lib/constants";
+import { FormSettings } from "@/components/builder/types";
 
 // Deduplicate getForm calls within the same request (generateMetadata + page body)
 const getFormCached = cache(getForm);
@@ -62,6 +63,7 @@ export default async function FormBuilderPage({
       initialMessages={messages}
       createdAt={form?.createdAt?.toISOString()}
       responseCount={responseCount}
+      initialFormSettings={form as unknown as FormSettings}
     />
   );
 }

--- a/src/app/forms/[id]/page.tsx
+++ b/src/app/forms/[id]/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
+import { cache, Suspense } from "react";
 import FormAssistantClient from "@/components/form-assistant-client";
 import { getForm, isFormAcceptingResponses } from "@/db/storage";
 import { FormSettings } from "@/components/builder/types";
 import { notFound } from "next/navigation";
 import FormClosedPage from "@/components/form-closed";
+
+// Deduplicate getForm calls within the same request (generateMetadata + page body)
+const getFormCached = cache(getForm);
 
 export async function generateMetadata({
   params,
@@ -12,7 +15,7 @@ export async function generateMetadata({
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
   const { id } = await params;
-  const form = await getForm(id);
+  const form = await getFormCached(id);
   if (!form) return { title: "Form Not Found" };
   return {
     title: form.title,
@@ -34,7 +37,7 @@ export default async function FormPage({
 
   let formSettings;
   try {
-    formSettings = await getForm(id);
+    formSettings = await getFormCached(id);
   } catch {
     notFound();
   }
@@ -42,7 +45,7 @@ export default async function FormPage({
     notFound();
   }
 
-  const { accepting, reason } = await isFormAcceptingResponses(id);
+  const { accepting, reason } = await isFormAcceptingResponses(id, formSettings);
   if (!accepting) {
     return <FormClosedPage title={formSettings.title} reason={reason} />;
   }

--- a/src/components/form-builder-client.tsx
+++ b/src/components/form-builder-client.tsx
@@ -20,6 +20,7 @@ interface FormBuilderProps {
   initialMessages?: Message[];
   createdAt?: string;
   responseCount?: number;
+  initialFormSettings?: FormSettings | null;
 }
 
 const tabs = [
@@ -35,6 +36,7 @@ export default function FormBuilder({
   initialMessages,
   createdAt,
   responseCount,
+  initialFormSettings,
 }: FormBuilderProps) {
   const getInitialTab = (): "chat" | "settings" | "results" | "overall-summary" | "share" => {
     if (typeof window === "undefined") return "chat";
@@ -64,7 +66,7 @@ export default function FormBuilder({
     updateFormSettings,
     formSettingsUpdated,
     setFormSettingsUpdated,
-  } = useFormSettings(messages, formId);
+  } = useFormSettings(messages, formId, initialFormSettings);
 
   const [copied, setCopied] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -78,6 +78,19 @@ export const getForm = async (id: string) => {
   return form[0];
 };
 
+/** Lightweight read — only the fields needed for the status-toggle action. */
+export const getFormStatusFields = async (id: string) => {
+  if (!db) {
+    throw new Error("Database not initialized");
+  }
+
+  const [form] = await db
+    .select({ status: forms.status, closedAt: forms.closedAt, userId: forms.userId })
+    .from(forms)
+    .where(eq(forms.id, id));
+  return form;
+};
+
 export const getUserForms = async (userId: string) => {
   if (!db) {
     throw new Error("Database not initialized");
@@ -190,13 +203,14 @@ export const getFormResponseCount = async (formId: string) => {
 export type FormClosedReason = "closed" | "scheduled" | "max_responses";
 
 export const isFormAcceptingResponses = async (
-  formId: string
+  formId: string,
+  preloadedForm?: Awaited<ReturnType<typeof getForm>>
 ): Promise<{ accepting: boolean; reason?: FormClosedReason }> => {
   if (!db) {
     throw new Error("Database not initialized");
   }
 
-  const form = await getForm(formId);
+  const form = preloadedForm ?? await getForm(formId);
   if (!form) return { accepting: false, reason: "closed" };
 
   if (form.status === "closed") return { accepting: false, reason: "closed" };
@@ -217,7 +231,7 @@ export const isFormAcceptingResponses = async (
 
 export const updateForm = async (
   id: string,
-  updatedForm: FormSettingsInsert,
+  updatedForm: Partial<FormSettingsInsert>,
   userId?: string
 ) => {
   if (!db) {

--- a/src/hooks/use-form-settings.ts
+++ b/src/hooks/use-form-settings.ts
@@ -15,20 +15,23 @@ interface UseFormSettingsResult {
 
 export function useFormSettings(
   messages: Message[],
-  formId: string
+  formId: string,
+  initialSettings?: FormSettings | null
 ): UseFormSettingsResult {
-  const [formSettings, setFormSettings] = useState<FormSettings | null>(null);
+  const [formSettings, setFormSettings] = useState<FormSettings | null>(
+    initialSettings ?? null
+  );
   const [lastFormUpdateMessageId, setLastFormUpdateMessageId] = useState<
     string | null
   >(null);
   const [formSettingsUpdated, setFormSettingsUpdated] = useState(false);
-  const [initialized, setInitialized] = useState(false);
+  const [initialized, setInitialized] = useState(!!initialSettings);
 
   useEffect(() => {
     if (!initialized) {
       const fetchFormSettings = async () => {
-        const formSettings = await getForm(formId);
-        setFormSettings(formSettings as FormSettings);
+        const fs = await getForm(formId);
+        setFormSettings(fs as FormSettings);
         setInitialized(true);
       };
       fetchFormSettings();


### PR DESCRIPTION
## Summary

- **`updateFormSettingsAction` field sanitization** — explicitly picks only the 16 safe user-settable fields before writing to DB. Prevents accidental overwrite of `messageHistory`, `userId`, `id`, `createdAt` when the runtime object carries extra DB-only properties (due to `as FormSettings` casts in `useFormSettings`)
- **`toggleFormStatusAction` targeted update** — replaces full form spread with `{ status, closedAt }` targeted update, avoiding an unnecessary rewrite of the entire `messageHistory` JSON on every status toggle. Also switches to a lightweight `getFormStatusFields` query instead of fetching the full row
- **`updateForm` type fix** — changed parameter from `FormSettingsInsert` to `Partial<FormSettingsInsert>` to correctly model partial-update semantics
- **Eliminate client-side `getForm` round-trip** — `useFormSettings` hook now accepts optional `initialSettings`; the builder page passes the server-loaded form, removing an extra RPC on every builder load
- **Public form page DB deduplication** — `React.cache(getForm)` deduplicates `generateMetadata` + `FormPage` calls; `isFormAcceptingResponses` now accepts a pre-loaded form, reducing up to 3 `getForm` DB queries per request down to 1

## Test plan

- [ ] Open a form in the builder — settings should load instantly (no loading flash)
- [ ] Save settings from the Settings tab — verify messageHistory is not affected
- [ ] Toggle form status from dashboard — verify status changes correctly
- [ ] Open a public form — verify it loads and accepting-responses check works
- [ ] Open a public form that is closed/at max — verify FormClosedPage renders with correct reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)