### PR TITLE
Fix: eliminate message duplication and redundant DB reads in hot paths

### DIFF
--- a/src/actions/form-assistant.ts
+++ b/src/actions/form-assistant.ts
@@ -9,10 +9,10 @@ import {
 } from "@/types/promp-schema";
 import { formAssistantSystemPrompt } from "@/system-prompts/assistant";
 import {
-  addFormSessionMessages,
   addFormSessionSummary,
   getForm,
   getFormSessionMessages,
+  setFormSessionMessages,
 } from "@/db/storage";
 import { ExtendedMessage } from "@/db/schema";
 import { trackEvent } from "@/lib/jitsu-server";
@@ -82,8 +82,6 @@ export async function sendMessage(
   }
   const newMessages: ExtendedMessage[] = [...messages, message];
 
-  await addFormSessionMessages(sessionId, [message]);
-
   const form = await getForm(formId);
   const formSettings: FormSettings = {
     title: form.title,
@@ -139,8 +137,9 @@ export async function sendMessage(
     saveSummary = true;
   }
 
+  // Save all messages in one write instead of two separate reads + writes
   await Promise.all([
-    addFormSessionMessages(sessionId, [assistantMessage]),
+    setFormSessionMessages(sessionId, newMessages),
     saveSummary && addFormSessionSummary(sessionId, result.object.summary),
     trackEvent("form-assistant-message", {
       formId,

--- a/src/actions/form-builder.ts
+++ b/src/actions/form-builder.ts
@@ -33,7 +33,7 @@ export async function sendMessage(formId: string, message: Message) {
 
   const messages = await getFormMessages(formId, userId);
   const newMessages: ExtendedMessage[] = [...messages, message];
-  await addFormMessages(formId, newMessages, userId);
+  await addFormMessages(formId, [message], userId);
 
   const result = await withAIErrorHandling((signal) =>
     generateObject({

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -12,7 +12,7 @@ import {
 import { db } from "@/db/db";
 import { and, count, desc, eq, gte, lte, max } from "drizzle-orm";
 import { FormAssistantResponse } from "@/actions/form-assistant";
-import { MAX_FORMS_PER_USER } from "@/lib/constants";
+import { MAX_BUILDER_MESSAGES_STORED, MAX_FORMS_PER_USER } from "@/lib/constants";
 
 export const createForm = async (newForm: FormSettingsInsert) => {
   if (!db) {
@@ -294,7 +294,9 @@ export const addFormMessages = async (
   }
 
   const existingMessages = await getFormMessages(id);
-  const updatedMessages = [...existingMessages, ...newMessages];
+  const combined = [...existingMessages, ...newMessages];
+  // Cap stored history to prevent unbounded DB growth; reads already use slice(-20)
+  const updatedMessages = combined.slice(-MAX_BUILDER_MESSAGES_STORED);
 
   const form = await db
     .update(forms)
@@ -329,11 +331,11 @@ export const getFormSessionMessages = async (id: string) => {
   if (!db) {
     throw new Error("Database not initialized");
   }
-  const formSession = await db
-    .select()
+  const [session] = await db
+    .select({ messageHistory: formSessions.messageHistory })
     .from(formSessions)
     .where(eq(formSessions.id, id));
-  return formSession[0]?.messageHistory || [];
+  return session?.messageHistory || [];
 };
 
 export const addFormSessionMessages = async (
@@ -352,6 +354,21 @@ export const addFormSessionMessages = async (
     .set({ messageHistory: updatedMessages })
     .where(eq(formSessions.id, id));
   return formSession;
+};
+
+/** Directly set the full message history for a session without fetching first. */
+export const setFormSessionMessages = async (
+  id: string,
+  messages: ExtendedMessage[]
+) => {
+  if (!db) {
+    throw new Error("Database not initialized");
+  }
+
+  return db
+    .update(formSessions)
+    .set({ messageHistory: messages })
+    .where(eq(formSessions.id, id));
 };
 
 export const addFormSessionSummary = async (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,5 +2,8 @@ export const MAX_FORMS_PER_USER = 10;
 
 export const MAX_SESSION_MESSAGES = 40;
 
+/** Maximum messages persisted in the builder's form.messageHistory */
+export const MAX_BUILDER_MESSAGES_STORED = 100;
+
 export const INITIAL_BUILDER_MESSAGE =
   "Let's start creating the form. Give me an idea of what is form created for?";


### PR DESCRIPTION
## Summary

- **Builder message duplication bug**: `form-builder.ts sendMessage` was calling `addFormMessages(formId, newMessages)` where `newMessages = [...existingMessages, userMessage]`. Since `addFormMessages` internally fetches existing messages and appends the passed array, this stored `[...existing, ...existing, userMessage]` — exponentially duplicating history on every message exchange
- **Consolidated assistant saves**: `form-assistant.ts sendMessage` was making 3 separate session messageHistory reads and 2 writes per message. Now builds the full message array in memory and calls `setFormSessionMessages` once at the end (1 read + 1 write)
- **New `setFormSessionMessages`**: Direct SET without internal fetch, for use when the caller already has the complete message array in memory
- **Targeted column select**: `getFormSessionMessages` now selects only `messageHistory` instead of the full row (avoids transferring summary/structuredData on every message send)
- **Cap stored builder history**: `addFormMessages` caps the stored `messageHistory` to `MAX_BUILDER_MESSAGES_STORED` (100) to prevent unbounded DB growth over long builder conversations

## Test plan

- [ ] Send a message in the builder — verify messageHistory isn't duplicated in subsequent exchanges
- [ ] Submit responses in a public form — verify messages are saved correctly
- [ ] Complete a form — verify the summary/structuredData is saved and session is marked completed
- [ ] Open a builder with an existing long conversation — verify it loads the last messages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)