### PR TITLE
fix: message history loss, silent failures, type safety, and hook correctness

### DIFF
--- a/src/actions/form-assistant.ts
+++ b/src/actions/form-assistant.ts
@@ -101,7 +101,7 @@ export async function sendMessage(
     role: msg.role,
     content: formatMessageContent(
       msg,
-      formSettings as unknown as FormSettings,
+      formSettings,
       index === newMessages.length - 1
     ),
   }));
@@ -149,7 +149,7 @@ export async function sendMessage(
 
   // Fire webhook if configured and form is completed
   if (saveSummary && form.webhookUrl && result.object.summary) {
-    fireWebhook(form.webhookUrl, {
+    void fireWebhook(form.webhookUrl, {
       formId,
       sessionId,
       completedAt: new Date().toISOString(),
@@ -157,23 +157,25 @@ export async function sendMessage(
       detailedSummary: result.object.summary.detailedSummary,
       overallSentiment: result.object.summary.overallSentiment,
       structuredAnswers: result.object.summary.structuredAnswers || [],
-    });
+    }).catch((err) => console.error("[webhook] delivery failed:", err));
   }
 
   // Send email notification if enabled
   if (saveSummary && form.emailNotifications === "on" && form.userId && result.object.summary) {
     const { getUserEmail } = await import("@/db/storage");
-    getUserEmail(form.userId).then((email) => {
-      if (email) {
-        sendResponseNotification({
-          to: email,
-          formTitle: form.title,
-          quickSummary: result.object.summary!.quickSummary,
-          sentiment: result.object.summary!.overallSentiment,
-          formId,
-        });
-      }
-    });
+    void getUserEmail(form.userId)
+      .then((email) => {
+        if (email) {
+          return sendResponseNotification({
+            to: email,
+            formTitle: form.title,
+            quickSummary: result.object.summary!.quickSummary,
+            sentiment: result.object.summary!.overallSentiment,
+            formId,
+          });
+        }
+      })
+      .catch((err) => console.error("[email notification] failed:", err));
   }
 
   return newMessages;

--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -57,13 +57,34 @@ export default async function FormBuilderPage({
     });
   }
 
+  const initialFormSettings: FormSettings | null = form
+    ? {
+        title: form.title,
+        tone: form.tone ?? "",
+        persona: form.persona ?? "",
+        keyInformation: form.keyInformation ?? [],
+        targetAudience: form.targetAudience ?? "",
+        expectedCompletionTime: form.expectedCompletionTime ?? "",
+        aboutBusiness: form.aboutBusiness ?? "",
+        welcomeMessage: form.welcomeMessage ?? "",
+        callToAction: form.callToAction ?? "",
+        endScreenMessage: form.endScreenMessage ?? "",
+        status: form.status,
+        closedAt: form.closedAt,
+        maxResponses: form.maxResponses,
+        webhookUrl: form.webhookUrl,
+        accentColor: form.accentColor,
+        emailNotifications: form.emailNotifications,
+      }
+    : null;
+
   return (
     <FormBuilderClient
       formId={id}
       initialMessages={messages}
       createdAt={form?.createdAt?.toISOString()}
       responseCount={responseCount}
-      initialFormSettings={form as unknown as FormSettings}
+      initialFormSettings={initialFormSettings}
     />
   );
 }

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -283,26 +283,27 @@ export const addFormMessages = async (
     throw new Error("Database not initialized");
   }
 
-  if (userId) {
-    const [existing] = await db
-      .select({ userId: forms.userId })
-      .from(forms)
-      .where(eq(forms.id, id));
-    if (!existing || existing.userId !== userId) {
-      throw new Error("Unauthorized: you do not own this form");
-    }
+  // Single query: fetch full messageHistory (and userId for auth check in one round-trip).
+  // NOTE: do NOT use getFormMessages here — it applies slice(-20) for AI context and
+  // would silently drop older messages from storage once history exceeds 20 entries.
+  const [existing] = await db
+    .select({ userId: forms.userId, messageHistory: forms.messageHistory })
+    .from(forms)
+    .where(eq(forms.id, id));
+
+  if (userId && (!existing || existing.userId !== userId)) {
+    throw new Error("Unauthorized: you do not own this form");
   }
 
-  const existingMessages = await getFormMessages(id);
+  const existingMessages = existing?.messageHistory ?? [];
   const combined = [...existingMessages, ...newMessages];
-  // Cap stored history to prevent unbounded DB growth; reads already use slice(-20)
+  // Cap stored history to prevent unbounded DB growth; reads for AI context use slice(-20)
   const updatedMessages = combined.slice(-MAX_BUILDER_MESSAGES_STORED);
 
-  const form = await db
+  return db
     .update(forms)
     .set({ messageHistory: updatedMessages })
     .where(eq(forms.id, id));
-  return form;
 };
 
 export const createFormSession = async (newFormSession: FormSessionsInsert) => {

--- a/src/hooks/use-form-settings.ts
+++ b/src/hooks/use-form-settings.ts
@@ -25,13 +25,37 @@ export function useFormSettings(
     string | null
   >(null);
   const [formSettingsUpdated, setFormSettingsUpdated] = useState(false);
-  const [initialized, setInitialized] = useState(!!initialSettings);
+  // When initialSettings is explicitly passed (even as null), skip the client-side fetch.
+  // Using !== undefined rather than !! so that null (server says "no settings") also
+  // counts as initialized and avoids a redundant getForm() round-trip.
+  const [initialized, setInitialized] = useState(initialSettings !== undefined);
 
   useEffect(() => {
     if (!initialized) {
       const fetchFormSettings = async () => {
         const fs = await getForm(formId);
-        setFormSettings(fs as FormSettings);
+        if (!fs) {
+          setInitialized(true);
+          return;
+        }
+        setFormSettings({
+          title: fs.title,
+          tone: fs.tone ?? "",
+          persona: fs.persona ?? "",
+          keyInformation: fs.keyInformation ?? [],
+          targetAudience: fs.targetAudience ?? "",
+          expectedCompletionTime: fs.expectedCompletionTime ?? "",
+          aboutBusiness: fs.aboutBusiness ?? "",
+          welcomeMessage: fs.welcomeMessage ?? "",
+          callToAction: fs.callToAction ?? "",
+          endScreenMessage: fs.endScreenMessage ?? "",
+          status: fs.status,
+          closedAt: fs.closedAt,
+          maxResponses: fs.maxResponses,
+          webhookUrl: fs.webhookUrl,
+          accentColor: fs.accentColor,
+          emailNotifications: fs.emailNotifications,
+        });
         setInitialized(true);
       };
       fetchFormSettings();
@@ -57,7 +81,8 @@ export function useFormSettings(
         }
       }
     }
-  }, [messages]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages, initialized]);
 
   // Function to manually update form settings
   const updateFormSettings = async (


### PR DESCRIPTION
## Summary

- **Task #121** — `addFormMessages` was reading history via `getFormMessages()` which applies `slice(-20)` for AI context, causing messages older than 20 to be silently dropped on every write. Now uses a single targeted query to read the full stored history — also collapses the separate auth-check query into the same round-trip
- **Task #122** — `fireWebhook()` and the email `getUserEmail().then()` chain in `form-assistant.ts` were fire-and-forget with no `.catch()`, so any failure was swallowed with no log entry; added `void` + `.catch(console.error)` to both
- **Task #123** — Removed redundant `as unknown as FormSettings` in `form-assistant.ts` (variable was already typed correctly); replaced the unsafe cast in `dashboard/[id]/page.tsx` with an explicit field-by-field mapping using `??` defaults to match `FormSettings`'s non-nullable string fields
- **Task #124** — Fixed `useFormSettings`: (1) `initialized` now uses `!== undefined` so passing `null` from the server correctly skips the client `getForm()` round-trip; (2) `initialized` added to the messages `useEffect` dependency array to prevent stale-closure risk; (3) replaced the unsafe `as FormSettings` cast in the fallback fetch path with proper field mapping

## Test plan

- [ ] Send >20 messages in the form builder — reload the page and verify all messages are still present
- [ ] Configure a webhook URL on a form, complete a session — verify the webhook fires (and any failure is logged, not silent)
- [ ] Enable email notifications — complete a session and verify notification fires
- [ ] Open the builder for an existing form — verify form settings load correctly without an extra network request
- [ ] TypeScript compile should pass with no new errors on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)